### PR TITLE
use BLAS in brute force (via NumPy)

### DIFF
--- a/ann_benchmarks.py
+++ b/ann_benchmarks.py
@@ -195,13 +195,12 @@ class BruteForce(BaseANN):
 
     def query(self, v, n):
         """Find indices of `n` most similar vectors from the index to query vector `v`."""
+        # HACK we ignore query length as that's a constant not affecting the final ordering
         if self._metric == 'angular':
-            query = v / numpy.sqrt((v ** 2).sum())  # normalize query to unit length
-            cossims = numpy.dot(self.index, query)  # cossim = dot product over normalized vectors
-            dists = -cossims  # just for convenience, so that lowest = best
+            # argmax_a cossim(a, b) = argmax_a dot(a, b) / |a||b| = argmin_a -dot(a, b)
+            dists = -numpy.dot(self.index, v)
         elif self._metric == 'euclidean':
-            # HACK we ignore query length as that's a constant not affecting the final ordering:
-            # argmax_a (a - b)^2 = argmax_a a^2 - 2ab + b^2 = argmax_a a^2 - 2ab
+            # argmin_a (a - b)^2 = argmin_a a^2 - 2ab + b^2 = argmin_a a^2 - 2ab
             dists = self.lengths - 2 * numpy.dot(self.index, v)
         else:
             assert False, "invalid metric"  # shouldn't get past the constructor!

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,6 @@
 sudo apt-get install -y python-numpy python-scipy
 cd install
-for fn in annoy.sh panns.sh nearpy.sh sklearn.sh flann.sh kgraph.sh glove.sh sift.sh
+for fn in bruteforce.sh annoy.sh panns.sh nearpy.sh sklearn.sh flann.sh kgraph.sh glove.sh sift.sh
 do
     source $fn
 done

--- a/install/bruteforce.sh
+++ b/install/bruteforce.sh
@@ -1,0 +1,3 @@
+sudo apt-get install -y python-pip python-dev
+sudo apt-get install -y libatlas-dev libatlas3gf-base
+sudo apt-get install -y python-numpy


### PR DESCRIPTION
Replace slow brute force algo (sklearn) by a direct, fast BLAS call.

Make sure you have a fast BLAS installed -- a recent ATLAS, or OpenBlas, Intel's MKL, Apple's Accelerate etc. This can make a huge difference in performance.

PR **not tested** at all. @erikbern can you run it on the AWS machine? I just wrote the code, I didn't get a chance to run it (install assumes Debian). Sorry for any typos.