### PR TITLE
Adding benchmarks for some of the Non-Metric Space Library Methods

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,6 +12,7 @@ Evaluated
 * `PANNS <https://github.com/ryanrhymes/panns>`__
 * `NearPy <http://nearpy.io>`__
 * `KGraph <https://github.com/aaalgo/kgraph>`__
+* `NonMetricSpaceLib <https://github.com/searchivarius/NonMetricSpaceLib>`__
 
 Data sets
 ---------
@@ -65,5 +66,4 @@ References
 ----------
 
 * `sim-shootout <https://github.com/piskvorky/sim-shootout>`__ by Radim Řehůřek
-* `NonMetricSpaceLib <https://github.com/searchivarius/NonMetricSpaceLib>`__
 * This `blog post <http://maheshakya.github.io/gsoc/2014/08/17/performance-comparison-among-lsh-forest-annoy-and-flann.html>`__

--- a/ann_benchmarks.py
+++ b/ann_benchmarks.py
@@ -2,6 +2,7 @@ import sklearn.neighbors
 import annoy
 import pyflann
 import panns
+import nmslib
 import nearpy, nearpy.hashes, nearpy.distances
 import pykgraph
 import gzip, numpy, time, os, multiprocessing, argparse, pickle, resource

--- a/ann_benchmarks.py
+++ b/ann_benchmarks.py
@@ -173,6 +173,26 @@ class KGraph(BaseANN):
         result = self._kgraph.search(self._X, numpy.array([v]), K=n, threads=1, P=self._P)
         return result[0]
 
+class Nmslib(BaseANN):
+    def __init__(self, metric, method_name, method_param):
+        self._nmslib_metric = {'angular': 'cosinesimil', 'euclidean': 'l2'}[metric]
+        self._method_name = method_name
+        self._method_param = method_param
+        self.name = 'Nmslib(method_name=%s, method_param=%s)' % (method_name, method_param)
+
+    def fit(self, X):
+        self._index = nmslib.initIndex(X.shape[0], self._nmslib_metric, [], self._method_name, self._method_param, nmslib.DataType.VECTOR, nmslib.DistType.FLOAT)
+	
+        for i, x in enumerate(X):
+            nmslib.setData(self._index, i, x.tolist())
+        nmslib.buildIndex(self._index)
+
+    def query(self, v, n):
+        return nmslib.knnQuery(self._index, n, v.tolist())
+
+    def freeIndex(self):
+        nmslib.freeIndex(self._index)
+
 
 class BruteForce(BaseANN):
     def __init__(self, metric):
@@ -260,7 +280,58 @@ def get_algos(m):
         'kgraph': [KGraph(m, 20), KGraph(m, 50), KGraph(m, 100), KGraph(m, 200), KGraph(m, 500), KGraph(m, 1000)],
         'bruteforce': [BruteForce(m)],
         'ball': [BallTree(m, 10), BallTree(m, 20), BallTree(m, 40), BallTree(m, 100), BallTree(m, 200), BallTree(m, 400), BallTree(m, 1000)],
-        'kd': [KDTree(m, 10), KDTree(m, 20), KDTree(m, 40), KDTree(m, 100), KDTree(m, 200), KDTree(m, 400), KDTree(m, 1000)]
+        'kd': [KDTree(m, 10), KDTree(m, 20), KDTree(m, 40), KDTree(m, 100), KDTree(m, 200), KDTree(m, 400), KDTree(m, 1000)],
+
+    # START: Non-Metric Space Library (nmslib) entries
+    'MP-lsh(lshkit)':[
+                Nmslib(m, 'lsh_multiprobe', ['desiredRecall=0.99','H=1200001','T=10','L=50','tuneK=10']),
+                Nmslib(m, 'lsh_multiprobe', ['desiredRecall=0.97','H=1200001','T=10','L=50','tuneK=10']),
+                Nmslib(m, 'lsh_multiprobe', ['desiredRecall=0.95','H=1200001','T=10','L=50','tuneK=10']),
+                Nmslib(m, 'lsh_multiprobe', ['desiredRecall=0.90','H=1200001','T=10','L=50','tuneK=10']),
+                Nmslib(m, 'lsh_multiprobe', ['desiredRecall=0.85','H=1200001','T=10','L=50','tuneK=10']),
+                Nmslib(m, 'lsh_multiprobe', ['desiredRecall=0.80','H=1200001','T=10','L=50','tuneK=10']),
+                Nmslib(m, 'lsh_multiprobe', ['desiredRecall=0.7','H=1200001','T=10','L=50','tuneK=10']),
+                Nmslib(m, 'lsh_multiprobe', ['desiredRecall=0.6','H=1200001','T=10','L=50','tuneK=10']),
+                Nmslib(m, 'lsh_multiprobe', ['desiredRecall=0.5','H=1200001','T=10','L=50','tuneK=10']),
+                Nmslib(m, 'lsh_multiprobe', ['desiredRecall=0.4','H=1200001','T=10','L=50','tuneK=10']),
+                Nmslib(m, 'lsh_multiprobe', ['desiredRecall=0.3','H=1200001','T=10','L=50','tuneK=10']),
+                Nmslib(m, 'lsh_multiprobe', ['desiredRecall=0.2','H=1200001','T=10','L=50','tuneK=10']),
+                Nmslib(m, 'lsh_multiprobe', ['desiredRecall=0.1','H=1200001','T=10','L=50','tuneK=10']),
+               ],
+
+    'bruteforce0(nmslib)': [Nmslib(m, 'seq_search', ['copyMem=0'])],
+    'bruteforce1(nmslib)': [Nmslib(m, 'seq_search', ['copyMem=1'])],
+
+    'BallTree(nmslib)': [
+                  Nmslib(m, 'vptree', ['tuneK=10', 'desiredRecall=0.99', 'bucketSize=100']),
+                  Nmslib(m, 'vptree', ['tuneK=10', 'desiredRecall=0.95', 'bucketSize=100']),
+                  Nmslib(m, 'vptree', ['tuneK=10', 'desiredRecall=0.90', 'bucketSize=100']),
+                  Nmslib(m, 'vptree', ['tuneK=10', 'desiredRecall=0.85', 'bucketSize=100']),
+                  Nmslib(m, 'vptree', ['tuneK=10', 'desiredRecall=0.8',  'bucketSize=100']),
+                  Nmslib(m, 'vptree', ['tuneK=10', 'desiredRecall=0.7',  'bucketSize=100']),
+                  Nmslib(m, 'vptree', ['tuneK=10', 'desiredRecall=0.6',  'bucketSize=100']),
+                  Nmslib(m, 'vptree', ['tuneK=10', 'desiredRecall=0.5',  'bucketSize=100']),
+                  Nmslib(m, 'vptree', ['tuneK=10', 'desiredRecall=0.4',  'bucketSize=100']),
+                  Nmslib(m, 'vptree', ['tuneK=10', 'desiredRecall=0.3',  'bucketSize=100']),
+                  Nmslib(m, 'vptree', ['tuneK=10', 'desiredRecall=0.2',  'bucketSize=100']),
+                  Nmslib(m, 'vptree', ['tuneK=10', 'desiredRecall=0.1',  'bucketSize=100']),
+                ],
+
+    'SW-graph(nmslib)':[
+                Nmslib(m, 'small_world_rand', ['NN=20', 'initIndexAttempts=4', 'initSearchAttempts=48']),
+                Nmslib(m, 'small_world_rand', ['NN=20', 'initIndexAttempts=4', 'initSearchAttempts=32']),
+                Nmslib(m, 'small_world_rand', ['NN=20', 'initIndexAttempts=4', 'initSearchAttempts=16']),
+                Nmslib(m, 'small_world_rand', ['NN=20', 'initIndexAttempts=4', 'initSearchAttempts=8']),
+                Nmslib(m, 'small_world_rand', ['NN=20', 'initIndexAttempts=4', 'initSearchAttempts=4']),
+                Nmslib(m, 'small_world_rand', ['NN=20', 'initIndexAttempts=4', 'initSearchAttempts=2']),
+                Nmslib(m, 'small_world_rand', ['NN=17', 'initIndexAttempts=4', 'initSearchAttempts=2']),
+                Nmslib(m, 'small_world_rand', ['NN=14', 'initIndexAttempts=4', 'initSearchAttempts=2']),
+                Nmslib(m, 'small_world_rand', ['NN=11', 'initIndexAttempts=5', 'initSearchAttempts=2']),
+                Nmslib(m, 'small_world_rand', ['NN=8',  'initIndexAttempts=5', 'initSearchAttempts=2']),
+                Nmslib(m, 'small_world_rand', ['NN=5',  'initIndexAttempts=5', 'initSearchAttempts=2']),
+                Nmslib(m, 'small_world_rand', ['NN=3',  'initIndexAttempts=5', 'initSearchAttempts=2']),
+               ]
+    # END: Non-Metric Space Library (nmslib) entries
     }
 
 

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,6 @@
 sudo apt-get install -y python-numpy python-scipy
 cd install
-for fn in annoy.sh panns.sh nearpy.sh sklearn.sh flann.sh kgraph.sh glove.sh sift.sh
+for fn in annoy.sh panns.sh nearpy.sh sklearn.sh flann.sh kgraph.sh nmslib.sh glove.sh sift.sh
 do
     source $fn
 done

--- a/install/glove.sh
+++ b/install/glove.sh
@@ -1,5 +1,4 @@
 wget "http://www-nlp.stanford.edu/data/glove.twitter.27B.100d.txt.gz"
-gzip -d glove.twitter.27B.100d.txt.gz
-rm glove.twitter.27B.100d.txt.gz
+gunzip -d glove.twitter.27B.100d.txt.gz
 cut -d " " -f 2- glove.twitter.27B.100d.txt > glove.txt # strip first column
 rm glove.twitter.27B.100d.txt

--- a/install/nmslib.sh
+++ b/install/nmslib.sh
@@ -5,7 +5,7 @@ rm -rf NonMetricSpaceLib
 git clone https://github.com/searchivarius/NonMetricSpaceLib.git
 cd NonMetricSpaceLib/similarity_search
 git checkout ann-benchmark  
-sudo apt-get install -y cmake libeigen3-dev libgsl0-dev libboost-all-dev g++-4.8
+sudo apt-get install -y cmake libeigen3-dev libgsl0-dev libboost-all-dev g++-4.8 g++ 
 cmake .
 make -j 4
 cd ../python_binding

--- a/install/nmslib.sh
+++ b/install/nmslib.sh
@@ -5,7 +5,9 @@ rm -rf NonMetricSpaceLib
 git clone https://github.com/searchivarius/NonMetricSpaceLib.git
 cd NonMetricSpaceLib/similarity_search
 git checkout ann-benchmark  
-sudo apt-get install -y cmake libeigen3-dev libgsl0-dev libboost-all-dev g++-4.8 g++ 
+sudo apt-get install -y cmake libeigen3-dev libgsl0-dev libboost-all-dev g++-4.8 
+# Actually let's make g++ an alias
+alias g++=g++-4.8
 cmake .
 make -j 4
 cd ../python_binding

--- a/install/nmslib.sh
+++ b/install/nmslib.sh
@@ -1,0 +1,14 @@
+echo "Installing Python interface for the Non-Metric Space Library"
+# Remove the previous version if existed
+rm -rf NonMetricSpaceLib 
+# Note that we use the develop branch here:
+git clone https://github.com/searchivarius/NonMetricSpaceLib.git
+cd NonMetricSpaceLib/similarity_search
+git checkout ann-benchmark  
+sudo apt-get install -y cmake libeigen3-dev libgsl0-dev libboost-all-dev g++-4.8
+cmake .
+make -j 4
+cd ../python_binding
+make
+sudo make install
+cd ..


### PR DESCRIPTION
Hi, please, consider the following pull request:

* SW-graph is a proximity graph implementation.
* MPLSH (multiprobe LSH). It is actually a ported implementation from LSHKit, which was written by Wei Dong (the kgraph guy :). Yet, it "sits" inside the Non-Metric Space Library and can be invoked like any other supported method. It works only for L2. I tried to use it for the cosine similarity/angular distance knn, but performance wasn't good.
* Ball-Tree (VP-tree) is a ball tree that can adjust its pruning algorithm. This works decently for many metric and **non-metric** spaces. It keeps its own copy of each bucket (see my comments below on cache misses).
* Two variants of the brute-force search: the variant **bruteforce1** copies all vectors to store them in a contiguous chunk of memory. 

Should you decide to benchmark computationally intensive distances, we can add a couple of other methods.

The recent changes are in the **ann-benchmark**. We are going to propagate them to the master soon (and make a mini-release).

L2/Cosine implementations use SSE2, but not AVX (which is slightly faster).

One reason why bruteforce performance may suck is that Python doesn't store vectors contiguously. Accessing these vectors incurs a lot of cache misses. One cache miss is roughly 500 CPU cycles, or 4 computations of L2 distances. For L2, I suspect, memory bandwidth is becoming a bottleneck. 

For SIFT signatures, you can store vectors as byte vectors and use [an efficient Wei Dong's implementation of L2 that relies on SIMD](https://github.com/aaalgo/kgraph/blob/master/metric.cpp#L119). Apparently, this can boost performance, at least in the multithreaded mode (due to bandwidth savings, or maybe it also uses fewer CPU cycles). However, this is not a generic solution. In fact, I recently learned that [RootSIFT](http://www.pyimagesearch.com/2015/04/13/implementing-rootsift-in-python-and-opencv/) performs better than raw SIFT. However, you can't apparently use the byte-storage trick with RootSIFT.

I made a test run on c4.4xlarge for some methods (results are below). However, I didn't re-run FLANN and only imported Eric's results (FLANN takes it really long to build an index):

**GLove/angular**
![Glove/angular](https://github.com/searchivarius/NonMetricSpaceLib/blob/ann-benchmark/python_binding/resultsAWS/glove.png?raw=true)

**SIFT/l2**
![SIFT/L2](https://github.com/searchivarius/NonMetricSpaceLib/blob/ann-benchmark/python_binding/resultsAWS/sift.png?raw=true)