### PR TITLE
Adding FALCONN

### DIFF
--- a/ann_benchmarks/__init__.py
+++ b/ann_benchmarks/__init__.py
@@ -49,7 +49,7 @@ class FALCONN(BaseANN):
         self._params.storage_hash_table = 'flat_hash_table'
         self._params.seed = 95225714
         self._index = falconn.LSHIndex(self._params)
-        self._index.fit(X)
+        self._index.setup(X)
         self._index.set_num_probes(self._num_probes)
         self._buf = numpy.zeros((X.shape[1],), dtype=numpy.float32)
 

--- a/install.sh
+++ b/install.sh
@@ -12,7 +12,7 @@ export CXX="g++-4.8" CC="gcc-4.8"
 pip install scikit-learn
 
 cd install
-for fn in annoy.sh panns.sh nearpy.sh sklearn.sh flann.sh kgraph.sh nmslib.sh rpforest.sh
+for fn in annoy.sh panns.sh nearpy.sh sklearn.sh flann.sh kgraph.sh nmslib.sh rpforest.sh falconn.sh
 do
     source $fn
 done

--- a/install/falconn.sh
+++ b/install/falconn.sh
@@ -1,0 +1,1 @@
+pip install falconn


### PR DESCRIPTION
I've added FALCONN (http://falconn-lib.org/) tuned for the GloVe dataset.

Here are the results for GloVe on the dedicated c4.2xlarge instance: https://gitlab.com/ilyaraz/experiments/blob/master/glove_results/ec2_flat.txt (other numbers are taken from the upstream of ann-benchmarks).

Here is the comparison of Annoy vs. FALCONN in one point *on the same instance* (to make sure that the numbers from the above make sense): http://pastebin.com/gpDVFQhm