### PR TITLE
Using NMSLIB code from a release rather than from an obscure branch

### DIFF
--- a/install/nmslib.sh
+++ b/install/nmslib.sh
@@ -2,8 +2,10 @@ cd "$(dirname "$0")"
 echo "Installing Python interface for the Non-Metric Space Library"
 # Remove the previous version if existed
 rm -rf nmslib 
-# Note that we use the pserv branch here:
-git clone https://github.com/searchivarius/nmslib.git
+# Note that we use version 1.5 here:
+#git clone https://github.com/searchivarius/nmslib.git
+wget https://github.com/searchivarius/nmslib/archive/v1.5.tar.gz
+tar -zxvf v1.5.tar.gz
 cd nmslib/similarity_search
 git checkout pserv
 apt-get install -y cmake libeigen3-dev libgsl0-dev

--- a/install/nmslib.sh
+++ b/install/nmslib.sh
@@ -6,7 +6,7 @@ rm -rf nmslib
 #git clone https://github.com/searchivarius/nmslib.git
 wget https://github.com/searchivarius/nmslib/archive/v1.5.tar.gz
 tar -zxvf v1.5.tar.gz
-cd nmslib/similarity_search
+cd nmslib-1.5/similarity_search
 git checkout pserv
 apt-get install -y cmake libeigen3-dev libgsl0-dev
 echo "CC: $CC, CXX: $CXX"

--- a/install/sift.sh
+++ b/install/sift.sh
@@ -2,7 +2,7 @@ cd "$(dirname "$0")"
 wget "ftp://ftp.irisa.fr/local/texmex/corpus/sift.tar.gz"
 tar -xzf sift.tar.gz
 rm -rf sift.tar.gz
-wget "https://raw.githubusercontent.com/searchivarius/NonMetricSpaceLib/master/data/data_conv/convert_texmex_fvec.py"
+wget "https://raw.githubusercontent.com/searchivarius/nmslib/v1.5/data/data_conv/convert_texmex_fvec.py"
 python convert_texmex_fvec.py sift/sift_base.fvecs >> sift.txt
 rm -rf sift
 


### PR DESCRIPTION
I have retested NMSLIB using the updated version (which downloads v1.5). Seems to be fine. If you were waiting for an updated version to run SIFT benchmarks, you can run them now. Even faster with saved indices. We don't cheat and don't save answers there :-) Only the indices themselves.

Additionally, I changed the source location of convert_texmex_fvec.py (to be from NMSLIB v1.5 too). I sometimes rename folders, it's not a good idea to pull it from master. Really, on a second thought: ann_benchmark could probably keep its own copy of convert_texmex_fvec.py.
