### PR TITLE
NYtimes dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ We have a number of precomputed data sets for this. All data sets are pre-split 
 | Glove                                                             |        100 |  1,133,628 |    59,886 |       100 | Angular   | [HDF5](http://vectors.erikbern.com/glove-100-angular.hdf5) (463MB)           |
 | Glove                                                             |        200 |  1,133,628 |    59,886 |       100 | Angular   | [HDF5](http://vectors.erikbern.com/glove-200-angular.hdf5) (918MB)           |
 | [MNIST](http://yann.lecun.com/exdb/mnist/)                        |        784 |     60,000 |    10,000 |       100 | Euclidean | [HDF5](http://vectors.erikbern.com/mnist-784-euclidean.hdf5) (217MB)         |
-| [NYTimes]() | 256 | 290,000 | 10,000 | 100 | Angular | **TODO**
+| [NYTimes](https://archive.ics.uci.edu/ml/datasets/bag+of+words) | 256 | 290,000 | 10,000 | 100 | Angular | **TODO**
 | [SIFT](https://corpus-texmex.irisa.fr/)                           |        128 |  1,000,000 |    10,000 |       100 | Euclidean | [HDF5](http://vectors.erikbern.com/sift-128-euclidean.hdf5) (501MB)          |
 
 Note that a few other datasets were used previously, in particular for Hamming and set similarity. We are going to add them back shortly in the more convenient HDF5 format.

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ We have a number of precomputed data sets for this. All data sets are pre-split 
 | Glove                                                             |        100 |  1,133,628 |    59,886 |       100 | Angular   | [HDF5](http://vectors.erikbern.com/glove-100-angular.hdf5) (463MB)           |
 | Glove                                                             |        200 |  1,133,628 |    59,886 |       100 | Angular   | [HDF5](http://vectors.erikbern.com/glove-200-angular.hdf5) (918MB)           |
 | [MNIST](http://yann.lecun.com/exdb/mnist/)                        |        784 |     60,000 |    10,000 |       100 | Euclidean | [HDF5](http://vectors.erikbern.com/mnist-784-euclidean.hdf5) (217MB)         |
+| [NYTimes]() | 256 | 290,000 | 10,000 | 100 | Angular | **TODO**
 | [SIFT](https://corpus-texmex.irisa.fr/)                           |        128 |  1,000,000 |    10,000 |       100 | Euclidean | [HDF5](http://vectors.erikbern.com/sift-128-euclidean.hdf5) (501MB)          |
 
 Note that a few other datasets were used previously, in particular for Hamming and set similarity. We are going to add them back shortly in the more convenient HDF5 format.

--- a/ann_benchmarks/datasets.py
+++ b/ann_benchmarks/datasets.py
@@ -148,12 +148,41 @@ def mnist(out_fn):
     write_output(train, test, out_fn, 'euclidean')
 
 
+
 def fashion_mnist(out_fn):
     download('http://fashion-mnist.s3-website.eu-central-1.amazonaws.com/train-images-idx3-ubyte.gz', 'fashion-mnist-train.gz')
     download('http://fashion-mnist.s3-website.eu-central-1.amazonaws.com/t10k-images-idx3-ubyte.gz', 'fashion-mnist-test.gz')
     train = _load_mnist_vectors('fashion-mnist-train.gz')
     test = _load_mnist_vectors('fashion-mnist-test.gz')
     write_output(train, test, out_fn, 'euclidean')
+
+def transform_bag_of_words(filename, n_dimensions, out_fn):
+    import gzip
+    import sklearn.model_selection
+    from scipy.sparse import lil_matrix
+    from sklearn.feature_extraction.text import TfidfTransformer
+    from sklearn import random_projection
+    with gzip.open(filename, 'rb') as f:
+        file_content = f.readlines()
+        entries = int(file_content[0])
+        words = int(file_content[1])
+        file_content = file_content[3:] # strip first three entries
+        print("building matrix...")
+        A = lil_matrix((entries, words))
+        for e in file_content:
+            doc, word, cnt = [int(v) for v in e.strip().split()]
+            A[doc - 1, word - 1] = cnt
+        print("normalizing matrix entries with tfidf...")
+        B = TfidfTransformer().fit_transform(A)
+        print("reducing dimensionality...")
+        C = random_projection.GaussianRandomProjection(n_components = n_dimensions).fit_transform(B)
+        X_train, X_test = sklearn.model_selection.train_test_split(C, test_size=10000, random_state=1)
+        print('writing output...')
+        write_output(numpy.array(X_train), numpy.array(X_test), out_fn, 'angular')
+
+def nytimes(out_fn, n_dimensions):
+    download('https://archive.ics.uci.edu/ml/machine-learning-databases/bag-of-words/docword.nytimes.txt.gz', 'nytimes.txt.gz')
+    transform_bag_of_words('nytimes.txt.gz', n_dimensions, out_fn)
 
 
 def random(out_fn, n_dims, n_samples, centers, distance):
@@ -163,8 +192,7 @@ def random(out_fn, n_dims, n_samples, centers, distance):
     X, _ = sklearn.datasets.make_blobs(n_samples=n_samples, n_features=n_dims, centers=centers, random_state=1)
     X_train, X_test = sklearn.model_selection.train_test_split(X, test_size=0.1, random_state=1)
     write_output(X_train, X_test, out_fn, distance)
-    
-    
+
 DATASETS = {
     'fashion-mnist-784-euclidean': fashion_mnist,
     'gist-960-euclidean': gist,
@@ -178,4 +206,5 @@ DATASETS = {
     'random-xs-10-angular': lambda out_fn: random(out_fn, 10, 10000, 100, 'angular'),
     'random-s-40-angular': lambda out_fn: random(out_fn, 40, 100000, 1000, 'angular'),
     'sift-128-euclidean': sift,
+    'nytimes-256-angular': lambda out_fn: nytimes(out_fn, 256),
 }

--- a/ann_benchmarks/datasets.py
+++ b/ann_benchmarks/datasets.py
@@ -148,13 +148,13 @@ def mnist(out_fn):
     write_output(train, test, out_fn, 'euclidean')
 
 
-
 def fashion_mnist(out_fn):
     download('http://fashion-mnist.s3-website.eu-central-1.amazonaws.com/train-images-idx3-ubyte.gz', 'fashion-mnist-train.gz')
     download('http://fashion-mnist.s3-website.eu-central-1.amazonaws.com/t10k-images-idx3-ubyte.gz', 'fashion-mnist-test.gz')
     train = _load_mnist_vectors('fashion-mnist-train.gz')
     test = _load_mnist_vectors('fashion-mnist-test.gz')
     write_output(train, test, out_fn, 'euclidean')
+
 
 def transform_bag_of_words(filename, n_dimensions, out_fn):
     import gzip
@@ -179,6 +179,7 @@ def transform_bag_of_words(filename, n_dimensions, out_fn):
         X_train, X_test = sklearn.model_selection.train_test_split(C, test_size=10000, random_state=1)
         print('writing output...')
         write_output(numpy.array(X_train), numpy.array(X_test), out_fn, 'angular')
+
 
 def nytimes(out_fn, n_dimensions):
     download('https://archive.ics.uci.edu/ml/machine-learning-databases/bag-of-words/docword.nytimes.txt.gz', 'nytimes.txt.gz')


### PR DESCRIPTION
This pull request adds support for the NYtimes dataset.  The NYTimes bag-of-words dataset is transformed into a 256 dimensional real-valued value by normalizing the word occurrences matrix using tfidf and then projecting done to 256 dimensions.

The bag-of-words transformation is kept general, since it potentially generalizes to other datasets.