### PR TITLE
Bring back create_website.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,4 +29,4 @@ script:
   - python run.py --docker-tag ann-benchmarks-${LIBRARY} --max-n-algorithms 5 --dataset random-xs-20-angular
   - python plot.py --dataset random-xs-20-angular --output plot.png
   - python -m unittest test/test-metrics.py
-  - python create-website.py --outputdir . --scatter --latex
+  - python create_website.py --outputdir . --scatter --latex

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,3 +28,4 @@ before_install:
 script:
   - python run.py --docker-tag ann-benchmarks-${LIBRARY} --max-n-algorithms 5 --dataset random-xs-20-angular
   - python plot.py --dataset random-xs-20-angular --output plot.png
+  - python -m unittest test/test-metrics.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,3 +29,4 @@ script:
   - python run.py --docker-tag ann-benchmarks-${LIBRARY} --max-n-algorithms 5 --dataset random-xs-20-angular
   - python plot.py --dataset random-xs-20-angular --output plot.png
   - python -m unittest test/test-metrics.py
+  - python create-website.py --outputdir . --scatter --latex

--- a/ann_benchmarks/plotting/metrics.py
+++ b/ann_benchmarks/plotting/metrics.py
@@ -1,30 +1,27 @@
 from __future__ import absolute_import
 
-def knn(dataset, run, epsilon=1e-10):
+def knn(dataset_distances, run_distances, count, epsilon=1e-10):
     total = 0
     actual = 0
-    count = int(run.attrs['candidates'])
-    for true_distances, found_distances in zip(dataset['distances'], run['distances']):
-        within = [d for d in found_distances[:count] if d <= true_distances[count] + epsilon]
+    for true_distances, found_distances in zip(dataset_distances, run_distances):
+        within = [d for d in found_distances[:count] if d <= true_distances[count - 1] + epsilon]
         total += count
         actual += len(within)
     return float(actual) / float(total)
 
-def epsilon(dataset, run, epsilon=0.01):
+def epsilon(dataset_distances, run_distances, count, epsilon=0.01):
     total = 0
     actual = 0
-    count = int(run.attrs['candidates'])
-    for true_distances, found_distances in zip(dataset['distances'], run['distances']):
-        within = [d for d in found_distances[:count] if d <= true_distances[count] * (1 + epsilon)]
+    for true_distances, found_distances in zip(dataset_distances, run_distances):
+        within = [d for d in found_distances[:count] if d <= true_distances[count - 1] * (1 + epsilon)]
         total += count
         actual += len(within)
     return float(actual) / float(total)
 
-def rel(dataset, run):
+def rel(dataset_distances, run_distances):
     total_closest_distance = 0.0
     total_candidate_distance = 0.0
-    count = int(run.attrs['candidates'])
-    for true_distances, found_distances in zip(dataset['distances'], run['distances']):
+    for true_distances, found_distances in zip(dataset_distances, run_distances):
         for rdist, cdist in zip(true_distances, found_distances):
             total_closest_distance += rdist
             total_candidate_distance += cdist
@@ -32,64 +29,67 @@ def rel(dataset, run):
         return float("inf")
     return total_candidate_distance / total_closest_distance
 
-def queries_per_second(queries, run):
-    return 1.0 / run.attrs["best_search_time"]
+def queries_per_second(queries, attrs):
+    return 1.0 / attrs["best_search_time"]
 
-def index_size(queries, run):
+def index_size(queries, attrs):
     # TODO(erikbern): should replace this with peak memory usage or something
-    return run.attrs.get("index_size", 0)
+    return attrs.get("index_size", 0)
 
-def build_time(queries, run):
-    return run.attrs["build_time"]
+def build_time(queries, attrs):
+    return attrs["build_time"]
 
-def candidates(queries, run):
-    return run.attrs["candidates"]
+def candidates(queries, attrs):
+    return attrs["candidates"]
 
 all_metrics = {
     "k-nn": {
         "description": "Recall",
-        "function": knn,
+        "function": lambda dataset, run, count: knn(dataset['distances'], run['distances'],
+            count),
         "worst": float("-inf"),
         "lim": [0.0, 1.03]
     },
     "epsilon": {
         "description": "Epsilon 0.01 Recall",
-        "function": epsilon,
+        "function": lambda dataset, run, count: epsilon(dataset['distances'], run['distances'],
+            count),
         "worst": float("-inf")
     },
     "largeepsilon": {
         "description": "Epsilon 0.1 Recall",
-        "function": lambda a,b: epsilon(a, b, 0.1),
+        "function": lambda dataset, run, count: epsilon(dataset['distances'], run['distances'],
+            count, 0.1),
         "worst": float("-inf")
     },
     "rel": {
         "description": "Relative Error",
-        "function": rel,
+        "function": lambda dataset, run, count: rel(dataset['distances'], run['distances']),
         "worst": float("inf")
     },
     "qps": {
         "description": "Queries per second (1/s)",
-        "function": queries_per_second,
+        "function": lambda dataset, run, count: queries_per_second(dataset, run.attrs),
         "worst": float("-inf")
     },
     "build": {
         "description": "Build time (s)",
-        "function": build_time,
+        "function": lambda dataset, run, count: build_time(dataset, run.attrs),
         "worst": float("inf")
     },
     "candidates" : {
         "description": "Candidates generated",
-        "function": candidates,
+        "function": lambda dataset, run, count: candidates(dataset, run.attrs),
         "worst": float("inf")
     },
     "indexsize" : {
         "description": "Index size (kB)",
-        "function": index_size,
+        "function": lambda dataset, run, count: index_size(dataset, run.attrs),
         "worst": float("inf")
     },
     "queriessize" : {
         "description": "Index size (kB)/Queries per second (s)",
-        "function": lambda a, b: index_size(a,b) / queries_per_second(a,b),
+        "function": lambda dataset, run, count: index_size(dataset, run.attrs) / queries_per_second(dataset, run.attrs),
         "worst": float("inf")
     }
 }

--- a/ann_benchmarks/plotting/metrics.py
+++ b/ann_benchmarks/plotting/metrics.py
@@ -1,20 +1,18 @@
 from __future__ import absolute_import
 
 def knn(dataset_distances, run_distances, count, epsilon=1e-10):
-    total = 0
+    total = len(run_distances) * count
     actual = 0
     for true_distances, found_distances in zip(dataset_distances, run_distances):
         within = [d for d in found_distances[:count] if d <= true_distances[count - 1] + epsilon]
-        total += count
         actual += len(within)
     return float(actual) / float(total)
 
 def epsilon(dataset_distances, run_distances, count, epsilon=0.01):
-    total = 0
+    total = len(run_distances) * count
     actual = 0
     for true_distances, found_distances in zip(dataset_distances, run_distances):
         within = [d for d in found_distances[:count] if d <= true_distances[count - 1] * (1 + epsilon)]
-        total += count
         actual += len(within)
     return float(actual) / float(total)
 
@@ -45,51 +43,48 @@ def candidates(queries, attrs):
 all_metrics = {
     "k-nn": {
         "description": "Recall",
-        "function": lambda dataset, run, count: knn(dataset['distances'], run['distances'],
-            count),
+        "function": lambda true_distances, run_distances, run_attrs: knn(true_distances, run_distances, run_attrs["count"]),
         "worst": float("-inf"),
         "lim": [0.0, 1.03]
     },
     "epsilon": {
         "description": "Epsilon 0.01 Recall",
-        "function": lambda dataset, run, count: epsilon(dataset['distances'], run['distances'],
-            count),
+        "function": lambda true_distances, run_distances, run_attrs: epsilon(true_distances, run_distances, run_attrs["count"]),
         "worst": float("-inf")
     },
     "largeepsilon": {
         "description": "Epsilon 0.1 Recall",
-        "function": lambda dataset, run, count: epsilon(dataset['distances'], run['distances'],
-            count, 0.1),
+        "function": lambda true_distances, run_distances, run_attrs: epsilon(true_distances, run_distances, run_attrs["count"], 0.1),
         "worst": float("-inf")
     },
     "rel": {
         "description": "Relative Error",
-        "function": lambda dataset, run, count: rel(dataset['distances'], run['distances']),
+        "function": lambda true_distances, run_distances, run_attrs: rel(true_distances, run_distances),
         "worst": float("inf")
     },
     "qps": {
         "description": "Queries per second (1/s)",
-        "function": lambda dataset, run, count: queries_per_second(dataset, run.attrs),
+        "function": lambda true_distances, run_distances, run_attrs: queries_per_second(true_distances, run_attrs),
         "worst": float("-inf")
     },
     "build": {
         "description": "Build time (s)",
-        "function": lambda dataset, run, count: build_time(dataset, run.attrs),
+        "function": lambda true_distances, run_distances, run_attrs: build_time(true_distances, run_attrs),
         "worst": float("inf")
     },
     "candidates" : {
         "description": "Candidates generated",
-        "function": lambda dataset, run, count: candidates(dataset, run.attrs),
+        "function": lambda true_distances, run_distances, run_attrs: candidates(true_distances, run_attrs),
         "worst": float("inf")
     },
     "indexsize" : {
         "description": "Index size (kB)",
-        "function": lambda dataset, run, count: index_size(dataset, run.attrs),
+        "function": lambda true_distances, run_distances, run_attrs: index_size(true_distances, run_attrs),
         "worst": float("inf")
     },
     "queriessize" : {
         "description": "Index size (kB)/Queries per second (s)",
-        "function": lambda dataset, run, count: index_size(dataset, run.attrs) / queries_per_second(dataset, run.attrs),
+        "function": lambda true_distances, run_distances, run_attrs: index_size(true_distances, run_attrs) / queries_per_second(true_distances, run_attrs),
         "worst": float("inf")
     }
 }

--- a/ann_benchmarks/plotting/utils.py
+++ b/ann_benchmarks/plotting/utils.py
@@ -28,14 +28,14 @@ def create_pointset(data, xn, yn):
             ls.append(algo_name)
     return xs, ys, ls, axs, ays, als
 
-def compute_metrics(dataset, res, metric_1, metric_2):
+def compute_metrics(dataset, res, count, metric_1, metric_2):
     all_results = {}
     for i, (definition, run) in enumerate(res):
         algo = definition.algorithm
         algo_name = run.attrs['name']
 
-        metric_1_value = metrics[metric_1]['function'](dataset, run)
-        metric_2_value = metrics[metric_2]['function'](dataset, run)
+        metric_1_value = metrics[metric_1]['function'](dataset, run, count)
+        metric_2_value = metrics[metric_2]['function'](dataset, run, count)
 
         print('%3d: %80s %12.3f %12.3f' % (i, algo_name, metric_1_value, metric_2_value))
 

--- a/ann_benchmarks/plotting/utils.py
+++ b/ann_benchmarks/plotting/utils.py
@@ -33,6 +33,7 @@ def compute_metrics(true_nn_distances, res, metric_1, metric_2):
     for i, (definition, run) in enumerate(res):
         algo = definition.algorithm
         algo_name = run.attrs['name']
+        # cache distances to avoid access to hdf5 file
         run_distances = list(run['distances'])
 
         metric_1_value = metrics[metric_1]['function'](true_nn_distances, run_distances, run.attrs)
@@ -49,6 +50,7 @@ def compute_all_metrics(true_nn_distances, run, algo):
     print('--')
     print(algo_name)
     results = {}
+    # cache distances to avoid access to hdf5 file
     run_distances = list(run["distances"])
     run_attrs = dict(run.attrs)
     for name, metric in metrics.items():

--- a/ann_benchmarks/plotting/utils.py
+++ b/ann_benchmarks/plotting/utils.py
@@ -43,6 +43,18 @@ def compute_metrics(dataset, res, count, metric_1, metric_2):
 
     return all_results
 
+def compute_all_metrics(dataset, run, count, algo):
+    algo_name = run.attrs["name"]
+    print('--')
+    print(algo_name)
+    results = {}
+    for name, metric in metrics.items():
+        v = metric["function"](dataset, run, count)
+        results[name] = v
+        if v:
+            print('%s: %g' % (name, v))
+    return (algo, algo_name, results)
+
 def generate_n_colors(n):
     vs = numpy.linspace(0.4, 1.0, 7)
     colors = [(.9, .4, .4, 1.)]

--- a/ann_benchmarks/plotting/utils.py
+++ b/ann_benchmarks/plotting/utils.py
@@ -28,14 +28,15 @@ def create_pointset(data, xn, yn):
             ls.append(algo_name)
     return xs, ys, ls, axs, ays, als
 
-def compute_metrics(dataset, res, count, metric_1, metric_2):
+def compute_metrics(true_nn_distances, res, metric_1, metric_2):
     all_results = {}
     for i, (definition, run) in enumerate(res):
         algo = definition.algorithm
         algo_name = run.attrs['name']
+        run_distances = list(run['distances'])
 
-        metric_1_value = metrics[metric_1]['function'](dataset, run, count)
-        metric_2_value = metrics[metric_2]['function'](dataset, run, count)
+        metric_1_value = metrics[metric_1]['function'](true_nn_distances, run_distances, run.attrs)
+        metric_2_value = metrics[metric_2]['function'](true_nn_distances, run_distances, run.attrs)
 
         print('%3d: %80s %12.3f %12.3f' % (i, algo_name, metric_1_value, metric_2_value))
 
@@ -43,13 +44,15 @@ def compute_metrics(dataset, res, count, metric_1, metric_2):
 
     return all_results
 
-def compute_all_metrics(dataset, run, count, algo):
+def compute_all_metrics(true_nn_distances, run, algo):
     algo_name = run.attrs["name"]
     print('--')
     print(algo_name)
     results = {}
+    run_distances = list(run["distances"])
+    run_attrs = dict(run.attrs)
     for name, metric in metrics.items():
-        v = metric["function"](dataset, run, count)
+        v = metric["function"](true_nn_distances, run_distances, run_attrs)
         results[name] = v
         if v:
             print('%s: %g' % (name, v))

--- a/ann_benchmarks/results.py
+++ b/ann_benchmarks/results.py
@@ -30,3 +30,27 @@ def load_results(dataset, count, definitions):
             f = h5py.File(fn)
             yield definition, f
             f.close()
+
+def _get_leaf_paths(path):
+    if os.path.isdir(path):
+        for fragment in os.listdir(path):
+            for i in _get_leaf_paths(os.path.join(path, fragment)):
+                yield i
+    elif os.path.isfile(path):
+        yield path
+
+def load_all_results():
+    import re
+    #TODO(Martin) Must be adaptive to get_result_filename
+    regex = r"results\/(?P<dataset>[^\/]+)\/(?P<count>\d+)\/(?P<algorithm>[^\/]+)\/(?P<distance>[^_]+)_(?P<params>.*)"
+    for fn in _get_leaf_paths("results/"):
+        match = re.match(regex, fn)
+        if match:
+            d = {}
+            for k in ["count", "dataset", "distance", "algorithm"]:
+                d[k] = match.group(k)
+            d["count"] = int(d["count"])
+            f = h5py.File(fn)
+            yield d, f
+            f.close()
+

--- a/ann_benchmarks/results.py
+++ b/ann_benchmarks/results.py
@@ -41,16 +41,11 @@ def _get_leaf_paths(path):
 
 def load_all_results():
     import re
-    #TODO(Martin) Must be adaptive to get_result_filename
-    regex = r"results\/(?P<dataset>[^\/]+)\/(?P<count>\d+)\/(?P<algorithm>[^\/]+)\/(?P<distance>[^_]+)_(?P<params>.*)"
     for fn in _get_leaf_paths("results/"):
-        match = re.match(regex, fn)
-        if match:
-            d = {}
-            for k in ["count", "dataset", "distance", "algorithm"]:
-                d[k] = match.group(k)
-            d["count"] = int(d["count"])
+        try:
             f = h5py.File(fn)
-            yield d, f
+            yield f
             f.close()
+        except:
+            pass
 

--- a/ann_benchmarks/results.py
+++ b/ann_benchmarks/results.py
@@ -31,21 +31,13 @@ def load_results(dataset, count, definitions):
             yield definition, f
             f.close()
 
-def _get_leaf_paths(path):
-    if os.path.isdir(path):
-        for fragment in os.listdir(path):
-            for i in _get_leaf_paths(os.path.join(path, fragment)):
-                yield i
-    elif os.path.isfile(path):
-        yield path
-
 def load_all_results():
-    import re
-    for fn in _get_leaf_paths("results/"):
-        try:
-            f = h5py.File(fn)
-            yield f
-            f.close()
-        except:
-            pass
+    for root, _, files in os.walk("results/"):
+        for fn in files:
+            try:
+                f = h5py.File(os.path.join(root, fn))
+                yield f
+                f.close()
+            except:
+                pass
 

--- a/ann_benchmarks/runner.py
+++ b/ann_benchmarks/runner.py
@@ -88,6 +88,10 @@ def run(definition, dataset, count, run_count=3, force_single=False, use_batch_q
             "name": algo.name,
             "run_count": run_count,
             "run_alone": force_single,
+            "distance": distance,
+            "count": int(count),
+            "algo": definition.algorithm,
+            "dataset": dataset
         }
         store_results(dataset, count, definition, attrs, results)
     finally:

--- a/create_website.py
+++ b/create_website.py
@@ -96,13 +96,15 @@ parser.add_argument(
     action = 'store_true')
 args = parser.parse_args()
 
-def get_latex_plot(all_data, xn, yn, xm, ym, plottype, j2_env):
+def get_latex_plot(all_data, xn, yn, xm, ym, render_all_points, j2_env):
     plot_data = []
     for algo in sorted(all_data.keys(), key=lambda x: x.lower()):
             xs, ys, ls, axs, ays, als = \
-                    create_pointset(prepare_data(all_data[algo], xn, yn), xn, yn)
+                create_pointset(prepare_data(all_data[algo], xn, yn), xn, yn)
+            if render_all_points:
+                xs, ys, ls = axs, ays, als
             plot_data.append({ "name": algo, "coords" : zip(xs, ys),
-                "scatter" : plottype == "bubble" })
+                "scatter" : render_all_points})
     return j2_env.get_template("latex.template").\
             render(plot_data = plot_data, caption = get_plot_label(xm, ym),
                     xlabel = xm["description"], ylabel = ym["description"])
@@ -133,16 +135,17 @@ def create_data_points(all_data, xn, yn, linestyle, render_all_points):
 
 def create_plot(all_data, xn, yn, linestyle, j2_env, additional_label = "", plottype = "line"):
     xm, ym = (metrics[xn], metrics[yn])
+    render_all_points = plottype == "bubble"
     return {"xlabel" :  xm["description"],
             "ylabel" : ym["description"],
             "plottype" : plottype,
             "plotlabel" : get_plot_label(xm, ym),
             "label": additional_label,
             "datapoints" : create_data_points(all_data, xn, yn,
-                linestyle, plottype == "bubble"),
+                linestyle, render_all_points),
             "buttonlabel" : hashlib.sha224((get_plot_label(xm, ym) +
                 additional_label).encode("utf-8")).hexdigest(),
-            "latexcode" :  get_latex_plot(all_data, xn, yn, xm, ym, plottype, j2_env)}
+            "latexcode" :  get_latex_plot(all_data, xn, yn, xm, ym, render_all_points, j2_env)}
 
 def build_detail_site(data, label_func, j2_env):
     for (name, runs) in data.items():

--- a/create_website.py
+++ b/create_website.py
@@ -127,6 +127,13 @@ def get_html_header(title):
           </div>
         </nav>""" % {"title" : title}
 
+def prepare_data(data, xn, yn):
+    """Change format from (algo, instance, dict) to (algo, instance, x, y)."""
+    res = []
+    for algo, algo_name, result in data:
+        res.append((algo, algo_name, result[xn], result[yn]))
+    return res
+
 def get_latex_plot(all_data, xm, ym, plottype):
     latex_str = """
 \\begin{figure}
@@ -147,7 +154,7 @@ def get_latex_plot(all_data, xm, ym, plottype):
     if plottype == "bubble":
         only_marks = "[only marks]"
     for algo in sorted(all_data.keys(), key=lambda x: x.lower()):
-            xs, ys, ls, axs, ays, als = create_pointset(all_data[algo], xn, yn)
+            xs, ys, ls, axs, ays, als = create_pointset(prepare_data(all_data[algo], xn, yn), xn, yn)
             latex_str += """
         \\addplot %s coordinates {""" % only_marks
             for i in range(len(xs)):
@@ -169,7 +176,7 @@ def create_data_points(all_data, xn, yn, linestyle, render_all_points):
     color_index = 0
     html_str = ""
     for algo in sorted(all_data.keys(), key=lambda x: x.lower()):
-            xs, ys, ls, axs, ays, als = create_pointset(all_data[algo], xn, yn)
+            xs, ys, ls, axs, ays, als = create_pointset(prepare_data(all_data[algo], xn, yn), xn, yn)
             if render_all_points:
                 xs, ys, ls = axs, ays, als
 # TODO Put this somewhere else
@@ -332,7 +339,10 @@ for (ds, runs) in all_runs_by_dataset.items():
             print("Processing scatterplot '%s' with %s" % (ds, plottype))
             output_str += create_plot(ds, runs, xn, yn, linestyles, "Scatterplot ", "bubble")
     # create png plot for summary page
-    plot.create_plot(runs, False,
+    data_for_plot = {}
+    for k in runs.keys():
+        data_for_plot[k] = prepare_data(runs[k], 'k-nn', 'qps')
+    plot.create_plot(data_for_plot, False,
             False, True, 'k-nn', 'qps',  args.outputdir + ds + ".png",
             create_linestyles(all_algos))
     output_str += """
@@ -357,7 +367,10 @@ for (algo, runs) in all_runs_by_algorithm.items():
         linestyles = convert_linestyle(create_linestyles(all_data))
         print("Processing '%s' with %s" % (algo, plottype))
         output_str += create_plot(algo, runs, xn, yn, linestyles)
-    plot.create_plot(runs, False,
+    data_for_plot = {}
+    for k in runs.keys():
+        data_for_plot[k] = prepare_data(runs[k], 'k-nn', 'qps')
+    plot.create_plot(data_for_plot, False,
             False, True, 'k-nn', 'qps',  args.outputdir + algo + ".png",
             create_linestyles(all_data))
     output_str += """

--- a/create_website.py
+++ b/create_website.py
@@ -64,10 +64,6 @@ parser.add_argument(
     type=directory_path,
     action = 'store')
 parser.add_argument(
-    '--definitions',
-    help = 'YAML file with dataset and algorithm annotations',
-    action = 'store')
-parser.add_argument(
     '--latex',
     help='generates latex code for each plot',
     action = 'store_true')
@@ -362,12 +358,6 @@ def build_website_for_algorithms(algorithms):
 
 def build_index(datasets, algorithms):
     with open(args.outputdir + "index.html", "w") as text_file:
-        try:
-            with open(args.definitions) as f:
-                definitions = yaml.load(f)
-        except:
-            print("Could not load definitions file, annotations not available.")
-            definitions = {}
         output_str = get_html_header("ANN-Benchmarks")
         output_str += """
             <div class="container">
@@ -428,14 +418,6 @@ def build_index(datasets, algorithms):
                     <div class = "col-md-4 bg-success">
                         <h4>%(name)s</h4>
                         <dl class="dl-horizontal">
-                        """ % { "name" : algo }
-            if "alogs" in definitions and algo in definitions["algos"]:
-                for k in definitions["algos"][algo]:
-                    output_str += """
-                            <dt>%s</dt>
-                            <dd>%s</dd>
-                            """ % (k, str(definitions["algos"][algo][k]))
-            output_str += """
                     </dl>
                 </div>
                 <div class = "col-md-8">

--- a/create_website.py
+++ b/create_website.py
@@ -293,193 +293,193 @@ def create_plot(ds, all_data, xn, yn, linestyle, additional_label = "", plottype
         """ % {  "latexcode": get_latex_plot(all_data, xm, ym, plottype), "buttonlabel" : hashlib.sha224(get_plot_label(xm, ym) + additional_label).hexdigest() }
     return output_str
 
-all_runs_by_dataset = {}
-dataset_information = {}
-all_runs_by_algorithm = {}
-
-for f in results.load_all_results():
-    sdn = "%(dataset)s_%(count)d_%(distance)s" % f.attrs
-    dataset = get_dataset(f.attrs["dataset"])
-    ms = compute_all_metrics(dataset, f, f.attrs["count"], f.attrs["algo"])
-    algo, _, _ = ms
-
-    if not algo in all_runs_by_algorithm:
-        all_runs_by_algorithm[algo] = {}
-    algo_ds = f.attrs["dataset"] + " (k = " + str(f.attrs["count"]) + ")"
-    if not algo_ds in all_runs_by_algorithm[algo]:
-        all_runs_by_algorithm[algo][algo_ds] = []
-    all_runs_by_algorithm[algo][algo_ds].append(ms)
-
-    if not sdn in all_runs_by_dataset:
-        all_runs_by_dataset[sdn] = {}
-        dataset_information[sdn] = dict(f.attrs)
-    if not algo in all_runs_by_dataset[sdn]:
-        all_runs_by_dataset[sdn][algo] = []
-    all_runs_by_dataset[sdn][algo].append(ms)
 
 # Build a website for each dataset
-for (ds, runs) in all_runs_by_dataset.items():
-    all_algos = runs.keys()
-    linestyles = convert_linestyle(create_linestyles(all_algos))
-    output_str = get_html_header(ds)
-    ds_name = dataset_information[ds]["dataset"] + " (k = " + str(dataset_information[ds]["count"]) + ")"
-    output_str += """
-        <div class="container">
-        <h2>Plots for %(id)s</h2>""" % { "id" : ds_name }
-    for plottype in args.plottype:
-        xn, yn = plot_variants[plottype]
-        print("Processing '%s' with %s" % (ds, plottype))
-        output_str += create_plot(ds_name, runs, xn, yn, linestyles)
-    if args.scatter:
+def build_website_for_datasets(datasets):
+    for (ds, runs) in datasets.items():
+        all_algos = runs.keys()
+        linestyles = convert_linestyle(create_linestyles(all_algos))
+        output_str = get_html_header(ds)
+        ds_name = query_info[ds]["dataset"] + " (k = " + str(query_info[ds]["count"]) + ")"
         output_str += """
-        <hr />
-        <h2>Scatterplots for %(id)s""" % { "id" : ds_name }
+            <div class="container">
+            <h2>Plots for %(id)s</h2>""" % { "id" : ds_name }
         for plottype in args.plottype:
             xn, yn = plot_variants[plottype]
-            print("Processing scatterplot '%s' with %s" % (ds, plottype))
-            output_str += create_plot(ds, runs, xn, yn, linestyles, "Scatterplot ", "bubble")
-    # create png plot for summary page
-    data_for_plot = {}
-    for k in runs.keys():
-        data_for_plot[k] = prepare_data(runs[k], 'k-nn', 'qps')
-    plot.create_plot(data_for_plot, False,
-            False, True, 'k-nn', 'qps',  args.outputdir + ds + ".png",
-            create_linestyles(all_algos))
-    output_str += """
+            print("Processing '%s' with %s" % (ds, plottype))
+            output_str += create_plot(ds_name, runs, xn, yn, linestyles)
+        if args.scatter:
+            output_str += """
+            <hr />
+            <h2>Scatterplots for %(id)s""" % { "id" : ds_name }
+            for plottype in args.plottype:
+                xn, yn = plot_variants[plottype]
+                print("Processing scatterplot '%s' with %s" % (ds, plottype))
+                output_str += create_plot(ds, runs, xn, yn, linestyles, "Scatterplot ", "bubble")
+        # create png plot for summary page
+        data_for_plot = {}
+        for k in runs.keys():
+            data_for_plot[k] = prepare_data(runs[k], 'k-nn', 'qps')
+        plot.create_plot(data_for_plot, False,
+                False, True, 'k-nn', 'qps',  args.outputdir + ds + ".png",
+                create_linestyles(all_algos))
+        output_str += """
+            </div>
         </div>
-    </div>
-    </body>
-</html>
-"""
-    with open(args.outputdir + ds + ".html", "w") as text_file:
-        text_file.write(output_str)
+        </body>
+    </html>
+    """
+        with open(args.outputdir + ds + ".html", "w") as text_file:
+            text_file.write(output_str)
 
 # Build a website for each algorithm
 # Build website. TODO Refactor with dataset code.
-for (algo, runs) in all_runs_by_algorithm.items():
-    all_data = runs.keys()
-    output_str = get_html_header(algo)
-    output_str += """
-        <div class="container">
-        <h2>Plots for %(id)s""" % { "id" : algo }
-    for plottype in args.plottype:
-        xn, yn = plot_variants[plottype]
-        linestyles = convert_linestyle(create_linestyles(all_data))
-        print("Processing '%s' with %s" % (algo, plottype))
-        output_str += create_plot(algo, runs, xn, yn, linestyles)
-    data_for_plot = {}
-    for k in runs.keys():
-        data_for_plot[k] = prepare_data(runs[k], 'k-nn', 'qps')
-    plot.create_plot(data_for_plot, False,
-            False, True, 'k-nn', 'qps',  args.outputdir + algo + ".png",
-            create_linestyles(all_data))
-    output_str += """
-    </div>
-    </body>
-</html>
-"""
-    with open(args.outputdir + algo + ".html", "w") as text_file:
+def build_website_for_algorithms(algorithms):
+    for (algo, runs) in algorithms.items():
+        all_data = runs.keys()
+        output_str = get_html_header(algo)
+        output_str += """
+            <div class="container">
+            <h2>Plots for %(id)s""" % { "id" : algo }
+        for plottype in args.plottype:
+            xn, yn = plot_variants[plottype]
+            linestyles = convert_linestyle(create_linestyles(all_data))
+            print("Processing '%s' with %s" % (algo, plottype))
+            output_str += create_plot(algo, runs, xn, yn, linestyles)
+        data_for_plot = {}
+        for k in runs.keys():
+            data_for_plot[k] = prepare_data(runs[k], 'k-nn', 'qps')
+        plot.create_plot(data_for_plot, False,
+                False, True, 'k-nn', 'qps',  args.outputdir + algo + ".png",
+                create_linestyles(all_data))
+        output_str += """
+        </div>
+        </body>
+    </html>
+    """
+        with open(args.outputdir + algo + ".html", "w") as text_file:
+            text_file.write(output_str)
+
+def build_index(datasets, algorithms):
+    with open(args.outputdir + "index.html", "w") as text_file:
+        try:
+            with open(args.definitions) as f:
+                definitions = yaml.load(f)
+        except:
+            print("Could not load definitions file, annotations not available.")
+            definitions = {}
+        output_str = get_html_header("ANN-Benchmarks")
+        output_str += """
+            <div class="container">
+                <h1>Info</h1>
+                <p>ANN-Benchmarks is a benchmarking environment for approximate nearest neighbor algorithms search. This website contains the current benchmarking results. Please visit <a href="http://github.com/erikbern/ann-benchmarks/">http://github.com/erikbern/ann-benchmarks/</a> to get an overview over evaluated data sets and algorithms. Make a pull request on <a href="http://github.com/erikbern/ann-benchmarks/">Github</a> to add your own code or improvements to the
+                benchmarking system.
+                </p>
+                <div id="results">
+                <h1>Benchmarking Results</h1>
+                <p>Results are split by distance measure and dataset. In the bottom, you can find an overview of an algorithm's performance on all datasets. Each dataset is annoted
+                by <em>(k = ...)</em>, the number of nearest neighbors an algorithm was supposed to return. The plot shown depicts <em>Recall</em> (the fraction
+                of true nearest neighbors found, on average over all queries) against <em>Queries per second</em>.  Clicking on a plot reveils detailled interactive plots, including
+                approximate recall, index size, and build time.</p>
+                <h2 id ="datasets">Results by Dataset</h2>
+                """
+
+        distance_measures = sorted(set([e.split("_")[-1] for e in datasets.keys()]))
+        sorted_datasets = sorted(set([e.split("_")[0] for e in datasets.keys()]))
+        for dm in distance_measures:
+            output_str += """
+                <h3>Distance: %s</h3>
+                """ % dm.capitalize()
+            for ds in sorted_datasets:
+                for idd in sorted([e for e in datasets.keys() \
+                        if e.split("_")[0] == ds and e.split("_")[-1] == dm], \
+                        key = lambda elem: int(elem.split("_")[1])):
+                    ds_name = query_info[idd]["dataset"] + " (k = " + \
+                        str(query_info[idd]["count"]) + ")"
+                    output_str += """
+                <a href="./%(id)s.html">
+                <div class="row" id="%(id)s">
+                    <div class = "col-md-4 bg-success">
+                        <h4>%(name)s</h4>
+                        <dl class="dl-horizontal">
+                        """ % { "name" : ds_name, "id" : idd }
+                    output_str += """
+                            </dl>
+                        </div>
+                        <div class = "col-md-8">
+                            <img class = "img-responsive" src="%(name)s.png" />
+                        </div>
+                    </div>
+                    </a>""" % { "name" : idd }
+            output_str += """
+                <hr />
+            """
+        output_str += """
+            <h2 id="algorithms">Results by Algorithm</h2>
+            <ul class="list-inline"><b>Algorithms:</b>"""
+        algorithm_names = algorithms.keys()
+        for algo in algorithm_names:
+            output_str += '<li><a href="#%(name)s">%(name)s</a></li>' % {"name" : algo}
+        output_str += "</ul>"
+        for algo in algorithm_names:
+            output_str += """
+                <a href="./%(name)s.html">
+                <div class="row" id="%(name)s">
+                    <div class = "col-md-4 bg-success">
+                        <h4>%(name)s</h4>
+                        <dl class="dl-horizontal">
+                        """ % { "name" : algo }
+            if "alogs" in definitions and algo in definitions["algos"]:
+                for k in definitions["algos"][algo]:
+                    output_str += """
+                            <dt>%s</dt>
+                            <dd>%s</dd>
+                            """ % (k, str(definitions["algos"][algo][k]))
+            output_str += """
+                    </dl>
+                </div>
+                <div class = "col-md-8">
+                    <img class = "img-responsive" src="%(name)s.png" />
+                </div>
+            </div>
+            </a>
+            <hr />""" % { "name" : algo}
+        output_str += """
+                <div id="contact">
+                <h2>Contact</h2>
+                <p>ANN-Benchmarks has been developed by Martin Aumueller (maau@itu.dk), Erik Bernhardsson (mail@erikbern.com), and Alec Faitfull (alef@itu.dk). Please use
+                <a href="https://github.com/erikbern/ann-benchmarks/">Github</a> to submit your implementation or improvements.</p>
+                </div>
+            </div>
+        </body>
+    </html>"""
         text_file.write(output_str)
 
-# Build an index page
-with open(args.outputdir + "index.html", "w") as text_file:
-    try:
-        with open(args.definitions) as f:
-            definitions = yaml.load(f)
-    except:
-        print("Could not load definitions file, annotations not available.")
-        definitions = {}
-    output_str = get_html_header("ANN-Benchmarks")
-    output_str += """
-        <div class="container">
-            <h1>Info</h1>
-            <p>ANN-Benchmarks is a benchmarking environment for approximate nearest neighbor algorithms search. This website contains the current benchmarking results. Please visit <a href="http://github.com/erikbern/ann-benchmarks/">http://github.com/erikbern/ann-benchmarks/</a> to get an overview over evaluated data sets and algorithms. Make a pull request on <a href="http://github.com/erikbern/ann-benchmarks/">Github</a> to add your own code or improvements to the
-            benchmarking system.
-            </p>
-            <div id="results">
-            <h1>Benchmarking Results</h1>
-            <p>Results are split by distance measure and dataset. In the bottom, you can find an overview of an algorithm's performance on all datasets. Each dataset is annoted
-            by <em>(k = ...)</em>, the number of nearest neighbors an algorithm was supposed to return. The plot shown depicts <em>Recall</em> (the fraction
-            of true nearest neighbors found, on average over all queries) against <em>Queries per second</em>.  Clicking on a plot reveils detailled interactive plots, including
-            approximate recall, index size, and build time.</p>
-            <h2 id ="datasets">Results by Dataset</h2>
-            """
+def load_all_results():
+    """Read all result files and compute all metrics"""
+    all_runs_by_dataset = {}
+    all_runs_by_algorithm = {}
+    query_info = {}
+    for f in results.load_all_results():
+        properties = dict(f.attrs)
+        # TODO Fix this properly. Sometimes the hdf5 file returns bytes
+        for k in properties.keys():
+            try:
+                properties[k]= properties[k].decode()
+            except:
+                pass
+        sdn = "%(dataset)s_%(count)d_%(distance)s" % properties
+        dataset = get_dataset(properties["dataset"])
+        algo = properties["algo"]
+        ms = compute_all_metrics(dataset, f, f.attrs["count"], f.attrs["algo"])
+        algo_ds = properties["dataset"] + " (k = " + str(f.attrs["count"]) + ")"
 
-    distance_measures = sorted(set([e.split("_")[-1] for e in all_runs_by_dataset.keys()]))
-    datasets = sorted(set([e.split("_")[0] for e in all_runs_by_dataset.keys()]))
-    for dm in distance_measures:
-        output_str += """
-            <h3>Distance: %s</h3>
-            """ % dm.capitalize()
-        for ds in datasets:
-            for idd in sorted([e for e in all_runs_by_dataset.keys() \
-                    if e.split("_")[0] == ds and e.split("_")[-1] == dm], \
-                    key = lambda elem: int(elem.split("_")[1])):
-                ds_name = dataset_information[idd]["dataset"] + " (k = " + \
-                    str(dataset_information[idd]["count"]) + ")"
-                output_str += """
-            <a href="./%(id)s.html">
-            <div class="row" id="%(id)s">
-                <div class = "col-md-4 bg-success">
-                    <h4>%(name)s</h4>
-                    <dl class="dl-horizontal">
-                    """ % { "name" : ds_name, "id" : idd }
-#        if "datasets" in definitions and ds in definitions["datasets"]:
-#            for k in definitions["datasets"][ds]:
-#                output_str += """
-#                        <dt>%s</dt>
-#                        <dd>%s</dd>
-#                        """ % (k, str(definitions["datasets"][ds][k]))
-                output_str += """
-                        </dl>
-                    </div>
-                    <div class = "col-md-8">
-                        <img class = "img-responsive" src="%(name)s.png" />
-                    </div>
-                </div>
-                </a>""" % { "name" : idd }
-        output_str += """
-            <hr />
-        """
-    output_str += """
-        <h2 id="algorithms">Results by Algorithm</h2>
-        <ul class="list-inline"><b>Algorithms:</b>"""
-    algorithms = all_runs_by_algorithm.keys()
-    for algo in algorithms:
-        output_str += '<li><a href="#%(name)s">%(name)s</a></li>' % {"name" : algo}
-    output_str += "</ul>"
-    for algo in algorithms:
-        output_str += """
-            <a href="./%(name)s.html">
-            <div class="row" id="%(name)s">
-                <div class = "col-md-4 bg-success">
-                    <h4>%(name)s</h4>
-                    <dl class="dl-horizontal">
-                    """ % { "name" : algo }
-        if "alogs" in definitions and algo in definitions["algos"]:
-            for k in definitions["algos"][algo]:
-                output_str += """
-                        <dt>%s</dt>
-                        <dd>%s</dd>
-                        """ % (k, str(definitions["algos"][algo][k]))
-        output_str += """
-                </dl>
-            </div>
-            <div class = "col-md-8">
-                <img class = "img-responsive" src="%(name)s.png" />
-            </div>
-        </div>
-        </a>
-        <hr />""" % { "name" : algo}
-    output_str += """
-            <div id="contact">
-            <h2>Contact</h2>
-            <p>ANN-Benchmarks has been developed by Martin Aumueller (maau@itu.dk), Erik Bernhardsson (mail@erikbern.com), and Alec Faitfull (alef@itu.dk). Please use
-            <a href="https://github.com/erikbern/ann-benchmarks/">Github</a> to submit your implementation or improvements.</p>
-            </div>
-        </div>
-    </body>
-</html>"""
-    text_file.write(output_str)
+        all_runs_by_algorithm.setdefault(algo, {}).setdefault(algo_ds, []).append(ms)
+        all_runs_by_dataset.setdefault(sdn, {}).setdefault(algo, []).append(ms)
+        query_info[sdn] = properties
+    return (all_runs_by_dataset, all_runs_by_algorithm, query_info)
 
-
+runs_by_ds, runs_by_algo, query_info = load_all_results()
+build_website_for_datasets(runs_by_ds)
+build_website_for_algorithms(runs_by_algo)
+build_index(runs_by_ds, runs_by_algo)

--- a/create_website.py
+++ b/create_website.py
@@ -416,7 +416,6 @@ def load_all_results():
     """Read all result files and compute all metrics"""
     all_runs_by_dataset = {}
     all_runs_by_algorithm = {}
-    query_info = {}
     for f in results.load_all_results():
         properties = dict(f.attrs)
         # TODO Fix this properly. Sometimes the hdf5 file returns bytes
@@ -434,10 +433,9 @@ def load_all_results():
 
         all_runs_by_algorithm.setdefault(algo, {}).setdefault(algo_ds, []).append(ms)
         all_runs_by_dataset.setdefault(sdn, {}).setdefault(algo, []).append(ms)
-        query_info[sdn] = properties
-    return (all_runs_by_dataset, all_runs_by_algorithm, query_info)
+    return (all_runs_by_dataset, all_runs_by_algorithm)
 
-runs_by_ds, runs_by_algo, query_info = load_all_results()
+runs_by_ds, runs_by_algo = load_all_results()
 build_detail_site(runs_by_ds, lambda label: get_dataset_label(label))
 build_detail_site(runs_by_algo, lambda x: x)
 build_index(runs_by_ds, runs_by_algo)

--- a/create_website.py
+++ b/create_website.py
@@ -344,7 +344,7 @@ def build_website_for_datasets(datasets):
         all_algos = runs.keys()
         linestyles = convert_linestyle(create_linestyles(all_algos))
         output_str = get_html_header(ds)
-        ds_name = query_info[ds]["dataset"] + " (k = " + str(query_info[ds]["count"]) + ")"
+        ds_name = get_dataset_from_desc(ds) + " (k = " + get_count_from_desc(ds) + ")"
         output_str += """
             <div class="container">
             <h2>Plots for %(id)s</h2>""" % { "id" : ds_name }
@@ -456,8 +456,8 @@ def load_all_results():
         sdn = get_run_desc(properties)
         dataset = get_dataset(properties["dataset"])
         algo = properties["algo"]
-        ms = compute_all_metrics(dataset, f, f.attrs["count"], f.attrs["algo"])
-        algo_ds = properties["dataset"] + " (k = " + str(f.attrs["count"]) + ")"
+        ms = compute_all_metrics(dataset, f, properties["count"], properties["algo"])
+        algo_ds = properties["dataset"] + " (k = " + str(properties["count"]) + ")"
 
         all_runs_by_algorithm.setdefault(algo, {}).setdefault(algo_ds, []).append(ms)
         all_runs_by_dataset.setdefault(sdn, {}).setdefault(algo, []).append(ms)

--- a/create_website.py
+++ b/create_website.py
@@ -9,7 +9,7 @@ from ann_benchmarks import results
 from ann_benchmarks.datasets import get_dataset
 from ann_benchmarks.plotting.plot_variants import all_plot_variants as plot_variants
 from ann_benchmarks.plotting.metrics import all_metrics as metrics
-from ann_benchmarks.plotting.utils  import get_plot_label, compute_metrics, create_pointset, create_linestyles
+from ann_benchmarks.plotting.utils  import get_plot_label, compute_metrics, compute_all_metrics, create_pointset, create_linestyles
 import plot
 
 colors = [
@@ -67,11 +67,6 @@ parser.add_argument(
     '--definitions',
     help = 'YAML file with dataset and algorithm annotations',
     action = 'store')
-parser.add_argument(
-    '--limit',
-    help='the maximum number of points to load from the dataset, or -1 to load all of them',
-    type=int,
-    default=-1)
 parser.add_argument(
     '--latex',
     help='generates latex code for each plot',
@@ -155,10 +150,10 @@ def get_latex_plot(all_data, xm, ym, plottype):
     if plottype == "bubble":
         only_marks = "[only marks]"
     for algo in sorted(all_data.keys(), key=lambda x: x.lower()):
-            xs, ys, ls, axs, ays, als = create_pointset(algo, all_data, xn, yn)
-            for i in range(len(ls)):
-                if "Subprocess" in ls[i]:
-                    ls[i] = ls[i].split("(")[1].split("{")[1].split("}")[0].replace("'", "")
+            xs, ys, ls, axs, ays, als = create_pointset(all_data[algo], xn, yn)
+#            for i in range(len(ls)):
+#                if "Subprocess" in ls[i]:
+#                    ls[i] = ls[i].split("(")[1].split("{")[1].split("}")[0].replace("'", "")
             latex_str += """
         \\addplot %s coordinates {""" % only_marks
             for i in range(len(xs)):
@@ -180,14 +175,14 @@ def create_data_points(all_data, xn, yn, linestyle, render_all_points):
     color_index = 0
     html_str = ""
     for algo in sorted(all_data.keys(), key=lambda x: x.lower()):
-            xs, ys, ls, axs, ays, als = create_pointset(algo, all_data, xn, yn)
+            xs, ys, ls, axs, ays, als = create_pointset(all_data[algo], xn, yn)
             if render_all_points:
                 xs, ys, ls = axs, ays, als
 # TODO Put this somewhere else
 # pretty print subprocess parameter settings.
-            for i in range(len(ls)):
-                if "Subprocess" in ls[i]:
-                    ls[i] = ls[i].split("(")[1].split("{")[1].split("}")[0].replace("'", "")
+#            for i in range(len(ls)):
+#                if "Subprocess" in ls[i]:
+#                    ls[i] = ls[i].split("(")[1].split("{")[1].split("}")[0].replace("'", "")
             html_str += """
                 {
                     label: "%(algo)s",

--- a/create_website.py
+++ b/create_website.py
@@ -429,7 +429,7 @@ def load_all_results():
         dataset = get_dataset(properties["dataset"])
         algo = properties["algo"]
         ms = compute_all_metrics(dataset, f, properties["count"], properties["algo"])
-        algo_ds = properties["dataset"] + " (k = " + str(properties["count"]) + ")"
+        algo_ds = get_dataset_label(sdn)
 
         all_runs_by_algorithm.setdefault(algo, {}).setdefault(algo_ds, []).append(ms)
         all_runs_by_dataset.setdefault(sdn, {}).setdefault(algo, []).append(ms)

--- a/create_website.py
+++ b/create_website.py
@@ -5,9 +5,8 @@ import os, json, pickle, yaml
 import numpy
 import hashlib
 
-from ann_benchmarks.main import get_fn
 from ann_benchmarks import results
-from ann_benchmarks import datasets
+from ann_benchmarks.datasets import get_dataset
 from ann_benchmarks.plotting.plot_variants import all_plot_variants as plot_variants
 from ann_benchmarks.plotting.metrics import all_metrics as metrics
 from ann_benchmarks.plotting.utils  import get_plot_label, compute_metrics, create_pointset, create_linestyles
@@ -353,7 +352,7 @@ for (ds, runs) in all_runs_by_dataset.items():
         <h2>Plots for %(id)s</h2>""" % { "id" : ds_name }
     for plottype in args.plottype:
         xn, yn = plot_variants[plottype]
-        print "Processing '%s' with %s" % (ds, plottype)
+        print("Processing '%s' with %s" % (ds, plottype))
         output_str += create_plot(ds_name, runs, xn, yn, linestyles)
     if args.scatter:
         output_str += """
@@ -361,7 +360,7 @@ for (ds, runs) in all_runs_by_dataset.items():
         <h2>Scatterplots for %(id)s""" % { "id" : ds_name }
         for plottype in args.plottype:
             xn, yn = plot_variants[plottype]
-            print "Processing scatterplot '%s' with %s" % (ds, plottype)
+            print("Processing scatterplot '%s' with %s" % (ds, plottype))
             output_str += create_plot(ds, runs, xn, yn, linestyles, "Scatterplot ", "bubble")
     # create png plot for summary page
     plot.create_plot(runs, True, False,
@@ -387,9 +386,9 @@ for (algo, runs) in all_runs_by_algorithm.items():
     for plottype in args.plottype:
         xn, yn = plot_variants[plottype]
         linestyles = convert_linestyle(create_linestyles(all_data))
-        print "Processing '%s' with %s" % (algo, plottype)
+        print("Processing '%s' with %s" % (algo, plottype))
         output_str += create_plot(algo, runs, xn, yn, linestyles)
-    plot.create_plot(runs, True, False,
+    plot.create_plot(runs, False,
             False, True, 'k-nn', 'qps',  args.outputdir + algo + ".png",
             create_linestyles(all_data))
     output_str += """
@@ -406,7 +405,7 @@ with open(args.outputdir + "index.html", "w") as text_file:
         with open(args.definitions) as f:
             definitions = yaml.load(f)
     except:
-        print "Could not load definitions file, annotations not available."
+        print("Could not load definitions file, annotations not available.")
         definitions = {}
     output_str = get_html_header("ANN-Benchmarks")
     output_str += """
@@ -496,7 +495,7 @@ with open(args.outputdir + "index.html", "w") as text_file:
             <div id="contact">
             <h2>Contact</h2>
             <p>ANN-Benchmarks has been developed by Martin Aumueller (maau@itu.dk), Erik Bernhardsson (mail@erikbern.com), and Alec Faitfull (alef@itu.dk). Please use
-            <a href="https://github.com/maau/ann-benchmarks/">Github</a> to submit your implementation or improvements.</p>
+            <a href="https://github.com/erikbern/ann-benchmarks/">Github</a> to submit your implementation or improvements.</p>
             </div>
         </div>
     </body>

--- a/create_website.py
+++ b/create_website.py
@@ -363,7 +363,7 @@ for (ds, runs) in all_runs_by_dataset.items():
             print("Processing scatterplot '%s' with %s" % (ds, plottype))
             output_str += create_plot(ds, runs, xn, yn, linestyles, "Scatterplot ", "bubble")
     # create png plot for summary page
-    plot.create_plot(runs, True, False,
+    plot.create_plot(runs, False,
             False, True, 'k-nn', 'qps',  args.outputdir + ds + ".png",
             create_linestyles(all_algos))
     output_str += """

--- a/create_website.py
+++ b/create_website.py
@@ -4,6 +4,7 @@ import argparse
 import os, json, pickle, yaml
 import numpy
 import hashlib
+from jinja2 import Environment, FileSystemLoader
 
 from ann_benchmarks import results
 from ann_benchmarks.datasets import get_dataset
@@ -65,6 +66,13 @@ def directory_path(s):
         raise argparse.ArgumentTypeError("'%s' is not a directory" % s)
     return s + "/"
 
+def prepare_data(data, xn, yn):
+    """Change format from (algo, instance, dict) to (algo, instance, x, y)."""
+    res = []
+    for algo, algo_name, result in data:
+        res.append((algo, algo_name, result[xn], result[yn]))
+    return res
+
 parser = argparse.ArgumentParser()
 parser.add_argument(
     '--plottype',
@@ -88,238 +96,23 @@ parser.add_argument(
     action = 'store_true')
 args = parser.parse_args()
 
-def get_html_header(title):
-    return """
-<!DOCTYPE html>
-    <html lang="en">
-      <head>
-        <meta charset="utf-8">
-        <meta http-equiv="X-UA-Compatible" content="IE=edge">
-        <meta name="viewport" content="width=device-width, initial-scale=1">
-        <!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
-        <title>%(title)s</title>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.5.0/Chart.js"></script>
-        <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
-        <!-- Include all compiled plugins (below), or include individual files as needed -->
-        <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
-        <!-- Bootstrap -->
-        <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
-        <style>
-            body { padding-top: 50px; }
-        </style>
-        <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
-        <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
-        <!--[if lt IE 9]>
-          <script src="https://oss.maxcdn.com/html5shiv/3.7.3/html5shiv.min.js"></script>
-          <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
-        <![endif]-->
-      </head>
-         <body>
-
-        <nav class="navbar navbar-inverse navbar-fixed-top">
-          <div class="container">
-            <div class="navbar-header">
-              <a class="navbar-brand" href="index.html">ANN Benchmarks</a>
-            </div>
-            <div id="navbar" class="collapse navbar-collapse">
-              <ul class="nav navbar-nav">
-                <li class="active"><a href="index.html">Home</a></li>
-              </ul>
-              <ul class="nav navbar-nav">
-                <li class="active"><a href="index.html#datasets">Datasets</a></li>
-              </ul>
-              <ul class="nav navbar-nav">
-                <li class="active"><a href="index.html#algorithms">Algorithms</a></li>
-              </ul>
-              <ul class="nav navbar-nav">
-                <li class="active"><a href="index.html#contact">Contact</a></li>
-              </ul>
-            </div><!--/.nav-collapse -->
-          </div>
-        </nav>""" % {"title" : title}
-
-def get_index_description():
-    return """
-        <div class="container">
-            <h1>Info</h1>
-            <p>ANN-Benchmarks is a benchmarking environment for approximate nearest neighbor algorithms search. This website contains the current benchmarking results. Please visit <a href="http://github.com/erikbern/ann-benchmarks/">http://github.com/erikbern/ann-benchmarks/</a> to get an overview over evaluated data sets and algorithms. Make a pull request on <a href="http://github.com/erikbern/ann-benchmarks/">Github</a> to add your own code or improvements to the
-            benchmarking system.
-            </p>
-            <div id="results">
-            <h1>Benchmarking Results</h1>
-            <p>Results are split by distance measure and dataset. In the bottom, you can find an overview of an algorithm's performance on all datasets. Each dataset is annoted
-            by <em>(k = ...)</em>, the number of nearest neighbors an algorithm was supposed to return. The plot shown depicts <em>Recall</em> (the fraction
-            of true nearest neighbors found, on average over all queries) against <em>Queries per second</em>.  Clicking on a plot reveils detailled interactive plots, including
-            approximate recall, index size, and build time.</p>
-            <h2 id ="datasets">Results by Dataset</h2>
-            """
-
-def get_index_footer():
-    return """
-            <div id="contact">
-            <h2>Contact</h2>
-            <p>ANN-Benchmarks has been developed by Martin Aumueller (maau@itu.dk), Erik Bernhardsson (mail@erikbern.com), and Alec Faitfull (alef@itu.dk). Please use
-            <a href="https://github.com/erikbern/ann-benchmarks/">Github</a> to submit your implementation or improvements.</p>
-            </div>
-        </div>
-    </body>
-</html>"""
-
-def get_row_desc(idd, desc):
-    return """
-        <a href="./%(idd)s.html">
-            <div class="row" id="%(idd)s">
-                <div class = "col-md-4 bg-success">
-                    <h4>%(desc)s</h4>
-            </div>
-            <div class = "col-md-8">
-                <img class = "img-responsive" src="%(idd)s.png" />
-            </div>
-        </div>
-        </a>
-        <hr />""" % { "idd" : idd, "desc" : desc}
-
-def prepare_data(data, xn, yn):
-    """Change format from (algo, instance, dict) to (algo, instance, x, y)."""
-    res = []
-    for algo, algo_name, result in data:
-        res.append((algo, algo_name, result[xn], result[yn]))
-    return res
-
-def get_latex_plot(all_data, xn, yn, xm, ym, plottype):
-    latex_str = """
-\\begin{figure}
-    \\centering
-    \\begin{tikzpicture}
-        \\begin{axis}[
-            xlabel={%(xlabel)s},
-            ylabel={%(ylabel)s},
-            ymode = log,
-            yticklabel style={/pgf/number format/fixed,
-                              /pgf/number format/precision=3},
-            legend style = { anchor=west},
-            cycle list name = black white
-            ]
-    """ % {"xlabel" : xm["description"], "ylabel" : ym["description"] }
-    color_index = 0
-    only_marks = ""
-    if plottype == "bubble":
-        only_marks = "[only marks]"
+def get_latex_plot(all_data, xn, yn, xm, ym, plottype, j2_env):
+    plot_data = []
     for algo in sorted(all_data.keys(), key=lambda x: x.lower()):
-            xs, ys, ls, axs, ays, als = create_pointset(prepare_data(all_data[algo], xn, yn), xn, yn)
-            latex_str += """
-        \\addplot %s coordinates {""" % only_marks
-            for i in range(len(xs)):
-                latex_str += "(%s, %s)" % (str(xs[i]), str(ys[i]))
-            latex_str += " };"
-            latex_str += """
-        \\addlegendentry{%s};
-            """ % (algo)
-    latex_str += """
-        \\end{axis}
-    \\end{tikzpicture}
-    \\caption{%(caption)s}
-    \\label{}
-\\end{figure}
-    """ % {"caption" : get_plot_label(xm, ym)}
-    return latex_str
-
-def get_latex_html(all_data, xn, yn, xm, ym, plottype, additional_label):
-    return """
-        <div class="row">
-            <div class="col-md-4 text-center">
-                <button type="button" id="button_%(buttonlabel)s" class="btn btn-default" >Toggle latex code</button>
-            </div>
-        </div>
-        <script>
-        $("#button_%(buttonlabel)s").click(function() {
-            $("#plot_%(buttonlabel)s").toggle();
-        });
-        </script>
-        <div id="plot_%(buttonlabel)s" style="display:none">
-            <pre>
-            %(latexcode)s
-            </pre>
-        </div>
-        """ % {  "latexcode": get_latex_plot(all_data, xn, yn, xm, ym, plottype), "buttonlabel" : hashlib.sha224((get_plot_label(xm, ym) + additional_label).encode("utf-8")).hexdigest() }
-
-def get_plot_html(data):
-        return """
-        <h3>%(xlabel)s/%(ylabel)s</h3>
-        <div id="%(xlabel)s%(ylabel)s%(label)s">
-            <canvas id="chart%(xlabel)s%(ylabel)s%(label)s" width="800" height="600"></canvas>
-            <script>
-                var ctx = document.getElementById("chart%(xlabel)s%(ylabel)s%(label)s");
-                var chart = new Chart(ctx, {
-                    type: "%(plottype)s",
-                    data: { datasets: [%(datapoints)s
-                        ]},
-                        options: {
-                            responsive: false,
-                            title:{
-                                display:true,
-                                text: '%(plotlabel)s'
-                            },
-                            scales: {
-                                xAxes: [{
-                                    display: true,
-                                    type: 'linear',
-                                    max: '1',
-                                    position: 'bottom',
-                                    scaleLabel: {
-                                        display: true,
-                                        labelString: ' %(xlabel)s   '
-                                    }
-                                }],
-                                yAxes: [{
-                                    display: true,
-                                    type: 'logarithmic',
-                                    scaleLabel: {
-                                        display: true,
-                                        labelString: ' %(ylabel)s '
-                                    }
-                                }]
-                            }
-                        }
-                    });
-                function pushOrConcat(base, toPush) {
-                        if (toPush) {
-                                if (Chart.helpers.isArray(toPush)) {
-                                        // base = base.concat(toPush);
-                                        Array.prototype.push.apply(base, toPush);
-                                } else {
-                                        base.push(toPush);
-                                }
-                        }
-
-                        return base;
-                }
-                Chart.Tooltip.prototype.getFooter = function(tooltipItem, data) {
-                    var me = this;
-                    var callbacks = me._options.callbacks;
-                    var item = tooltipItem[0];
-
-                    var beforeFooter = callbacks.beforeFooter.apply(me, arguments);
-                    var footer = "Parameters: " + data.datasets[item.datasetIndex].data[item.index].label || '';
-                    var afterFooter = callbacks.afterFooter.apply(me, arguments);
-
-                    var lines = [];
-                    lines = pushOrConcat(lines, beforeFooter);
-                    lines = pushOrConcat(lines, footer);
-                    lines = pushOrConcat(lines, afterFooter);
-
-                    return lines;
-                }
-
-                </script>
-            </div>
-                """ % data
+            xs, ys, ls, axs, ays, als = \
+                    create_pointset(prepare_data(all_data[algo], xn, yn), xn, yn)
+            plot_data.append({ "name": algo, "coords" : zip(xs, ys),
+                "scatter" : plottype == "bubble" })
+    return j2_env.get_template("latex.template").\
+            render(plot_data = plot_data, caption = get_plot_label(xm, ym),
+                    xlabel = xm["description"], ylabel = ym["description"])
 
 def create_data_points(all_data, xn, yn, linestyle, render_all_points):
     color_index = 0
     output_str = ""
     for algo in sorted(all_data.keys(), key=lambda x: x.lower()):
-            xs, ys, ls, axs, ays, als = create_pointset(prepare_data(all_data[algo], xn, yn), xn, yn)
+            xs, ys, ls, axs, ays, als = \
+                    create_pointset(prepare_data(all_data[algo], xn, yn), xn, yn)
             if render_all_points:
                 xs, ys, ls = axs, ays, als
             output_str += """
@@ -338,38 +131,34 @@ def create_data_points(all_data, xn, yn, linestyle, render_all_points):
             color_index += 1
     return output_str
 
-def create_plot(ds, all_data, xn, yn, linestyle, additional_label = "", plottype = "line"):
+def create_plot(all_data, xn, yn, linestyle, j2_env, additional_label = "", plottype = "line"):
     xm, ym = (metrics[xn], metrics[yn])
-    plot_data  =   { "id" : ds, "xlabel" :  xm["description"], "ylabel" : ym["description"], "plottype" : plottype,
-                        "plotlabel" : get_plot_label(xm, ym),  "label": additional_label,
-                        "datapoints" : create_data_points(all_data,
-                            xn, yn, linestyle, plottype == "bubble") }
-    output_str = get_plot_html(plot_data)
-    if args.latex:
-        output_str += get_latex_html(all_data, xn, yn, xm, ym, plottype, additional_label)
-    return output_str
+    return {"xlabel" :  xm["description"],
+            "ylabel" : ym["description"],
+            "plottype" : plottype,
+            "plotlabel" : get_plot_label(xm, ym),
+            "label": additional_label,
+            "datapoints" : create_data_points(all_data, xn, yn,
+                linestyle, plottype == "bubble"),
+            "buttonlabel" : hashlib.sha224((get_plot_label(xm, ym) +
+                additional_label).encode("utf-8")).hexdigest(),
+            "latexcode" :  get_latex_plot(all_data, xn, yn, xm, ym, plottype, j2_env)}
 
-def build_detail_site(data, label_func):
+def build_detail_site(data, label_func, j2_env):
     for (name, runs) in data.items():
+        print("Building '%s'" % name)
         all_runs = runs.keys()
         linestyles = convert_linestyle(create_linestyles(all_runs))
-        output_str = get_html_header(name)
         label = label_func(name)
-        output_str += """
-            <div class="container">
-            <h2>Plots for %s</h2>""" % (label)
+        data = {"normal" : [], "scatter" : []}
+
         for plottype in args.plottype:
             xn, yn = plot_variants[plottype]
-            print("Processing '%s' with %s" % (name, plottype))
-            output_str += create_plot(label, runs, xn, yn, linestyles)
-        if args.scatter:
-            output_str += """
-            <hr />
-            <h2>Scatterplots for %s""" % (label)
-            for plottype in args.plottype:
-                xn, yn = plot_variants[plottype]
-                print("Processing scatterplot '%s' with %s" % (name, plottype))
-                output_str += create_plot(name, runs, xn, yn, linestyles, "Scatterplot ", "bubble")
+            data["normal"].append(create_plot(runs, xn, yn, linestyles, j2_env))
+            if args.scatter:
+                data["scatter"].append(create_plot(runs, xn, yn,
+                    linestyles, j2_env, "Scatterplot ", "bubble"))
+
         # create png plot for summary page
         data_for_plot = {}
         for k in runs.keys():
@@ -377,27 +166,19 @@ def build_detail_site(data, label_func):
         plot.create_plot(data_for_plot, False,
                 False, True, 'k-nn', 'qps',  args.outputdir + name + ".png",
                 create_linestyles(all_runs))
-        output_str += """
-            </div>
-        </div>
-        </body>
-    </html>
-    """
         with open(args.outputdir + name + ".html", "w") as text_file:
-            text_file.write(output_str)
+            text_file.write(j2_env.get_template("detail_page.html").
+                render(title = label, plot_data = data, args = args))
 
 
-def build_index(datasets, algorithms):
+def build_index_site(datasets, algorithms, j2_env, file_name):
     distance_measures = sorted(set([get_distance_from_desc(e) for e in datasets.keys()]))
     sorted_datasets = sorted(set([get_dataset_from_desc(e) for e in datasets.keys()]))
 
-    output_str = get_html_header("ANN-Benchmarks")
-    output_str += get_index_description()
+    dataset_data = []
 
     for dm in distance_measures:
-        output_str += """
-            <h3>Distance: %s</h3>
-            """ % dm.capitalize()
+        d = {"name" : dm.capitalize(), "entries": []}
         for ds in sorted_datasets:
             matching_datasets = [e for e in datasets.keys() \
                     if get_dataset_from_desc(e) == ds and \
@@ -405,20 +186,13 @@ def build_index(datasets, algorithms):
             sorted_matches = sorted(matching_datasets, \
                     key = lambda e: int(get_count_from_desc(e)))
             for idd in sorted_matches:
-                output_str += get_row_desc(idd, get_dataset_label(idd))
-    output_str += """
-        <h2 id="algorithms">Results by Algorithm</h2>
-        <ul class="list-inline"><b>Algorithms:</b>"""
-    algorithm_names = algorithms.keys()
-    for algo in algorithm_names:
-        output_str += '<li><a href="#%(name)s">%(name)s</a></li>' % {"name" : algo}
-    output_str += "</ul>"
-    for algo in algorithm_names:
-        output_str += get_row_desc(algo, algo)
-    output_str += get_index_footer()
+                d["entries"].append({"name" : idd, "desc" : get_dataset_label(idd)})
+            dataset_data.append(d)
 
     with open(args.outputdir + "index.html", "w") as text_file:
-        text_file.write(output_str)
+        text_file.write(j2_env.get_template("summary.html").
+                render(title = "ANN-Benchmarks", dataset_with_distances = dataset_data,
+                    algorithms = algorithms.keys()))
 
 def load_all_results():
     """Read all result files and compute all metrics"""
@@ -449,6 +223,7 @@ def load_all_results():
     return (all_runs_by_dataset, all_runs_by_algorithm)
 
 runs_by_ds, runs_by_algo = load_all_results()
-build_detail_site(runs_by_ds, lambda label: get_dataset_label(label))
-build_detail_site(runs_by_algo, lambda x: x)
-build_index(runs_by_ds, runs_by_algo)
+j2_env = Environment(loader=FileSystemLoader("./templates/"), trim_blocks = True)
+build_detail_site(runs_by_ds, lambda label: get_dataset_label(label), j2_env)
+build_detail_site(runs_by_algo, lambda x: x, j2_env)
+build_index_site(runs_by_ds, runs_by_algo, j2_env, "index.html")

--- a/create_website.py
+++ b/create_website.py
@@ -424,6 +424,8 @@ def load_all_results():
     """Read all result files and compute all metrics"""
     all_runs_by_dataset = {}
     all_runs_by_algorithm = {}
+    cached_true_dist = []
+    old_sdn = None
     for f in results.load_all_results():
         properties = dict(f.attrs)
         # TODO Fix this properly. Sometimes the hdf5 file returns bytes
@@ -434,9 +436,12 @@ def load_all_results():
             except:
                 pass
         sdn = get_run_desc(properties)
-        dataset = get_dataset(properties["dataset"])
+        if sdn != old_sdn:
+            dataset = get_dataset(properties["dataset"])
+            cached_true_dist = list(dataset["distances"])
+            old_sdn = sdn
         algo = properties["algo"]
-        ms = compute_all_metrics(dataset, f, properties["count"], properties["algo"])
+        ms = compute_all_metrics(cached_true_dist, f, properties["algo"])
         algo_ds = get_dataset_label(sdn)
 
         all_runs_by_algorithm.setdefault(algo, {}).setdefault(algo_ds, []).append(ms)

--- a/create_website.py
+++ b/create_website.py
@@ -297,22 +297,22 @@ all_runs_by_dataset = {}
 dataset_information = {}
 all_runs_by_algorithm = {}
 
-for d, r in results.load_all_results():
-    sdn = "%(dataset)s_%(count)d__%(distance)s" % d
-    dataset = get_dataset(d["dataset"])
-    ms = compute_all_metrics(dataset, r, d["count"], d["algorithm"])
+for f in results.load_all_results():
+    sdn = "%(dataset)s_%(count)d_%(distance)s" % f.attrs
+    dataset = get_dataset(f.attrs["dataset"])
+    ms = compute_all_metrics(dataset, f, f.attrs["count"], f.attrs["algo"])
     algo, _, _ = ms
 
     if not algo in all_runs_by_algorithm:
         all_runs_by_algorithm[algo] = {}
-    algo_ds = d["dataset"] + " (k = " + str(d["count"]) + ")"
+    algo_ds = f.attrs["dataset"] + " (k = " + str(f.attrs["count"]) + ")"
     if not algo_ds in all_runs_by_algorithm[algo]:
         all_runs_by_algorithm[algo][algo_ds] = []
     all_runs_by_algorithm[algo][algo_ds].append(ms)
 
     if not sdn in all_runs_by_dataset:
         all_runs_by_dataset[sdn] = {}
-        dataset_information[sdn] = d
+        dataset_information[sdn] = dict(f.attrs)
     if not algo in all_runs_by_dataset[sdn]:
         all_runs_by_dataset[sdn][algo] = []
     all_runs_by_dataset[sdn][algo].append(ms)

--- a/create_website.py
+++ b/create_website.py
@@ -121,9 +121,6 @@ def get_html_header(title):
                 <li class="active"><a href="index.html#algorithms">Algorithms</a></li>
               </ul>
               <ul class="nav navbar-nav">
-                <li class="active"><a href="index.html#raw">Raw Data & Configuration</a></li>
-              </ul>
-              <ul class="nav navbar-nav">
                 <li class="active"><a href="index.html#contact">Contact</a></li>
               </ul>
             </div><!--/.nav-collapse -->
@@ -151,9 +148,6 @@ def get_latex_plot(all_data, xm, ym, plottype):
         only_marks = "[only marks]"
     for algo in sorted(all_data.keys(), key=lambda x: x.lower()):
             xs, ys, ls, axs, ays, als = create_pointset(all_data[algo], xn, yn)
-#            for i in range(len(ls)):
-#                if "Subprocess" in ls[i]:
-#                    ls[i] = ls[i].split("(")[1].split("{")[1].split("}")[0].replace("'", "")
             latex_str += """
         \\addplot %s coordinates {""" % only_marks
             for i in range(len(xs)):
@@ -386,7 +380,7 @@ with open(args.outputdir + "index.html", "w") as text_file:
     output_str += """
         <div class="container">
             <h1>Info</h1>
-            <p>ANN-Benchmarks is a benchmarking environment for approximate nearest neighbor algorithms search. This website contains the current benchmarking results. Please visit <a href="http://github.com/maumueller/ann-benchmarks/">http://github.com/maumueller/ann-benchmarks/</a> to get an overview over evaluated data sets and algorithms. Make a pull request on <a href="http://github.com/maumueller/ann-benchmarks/">Github</a> to add your own code or improvements to the
+            <p>ANN-Benchmarks is a benchmarking environment for approximate nearest neighbor algorithms search. This website contains the current benchmarking results. Please visit <a href="http://github.com/erikbern/ann-benchmarks/">http://github.com/erikbern/ann-benchmarks/</a> to get an overview over evaluated data sets and algorithms. Make a pull request on <a href="http://github.com/erikbern/ann-benchmarks/">Github</a> to add your own code or improvements to the
             benchmarking system.
             </p>
             <div id="results">
@@ -465,8 +459,6 @@ with open(args.outputdir + "index.html", "w") as text_file:
         </a>
         <hr />""" % { "name" : algo}
     output_str += """
-            <h2 id ="raw">Raw Data & Configuration</h2>
-            <p>Please find the raw experimental data <a href="./results-sisap.tar">here</a> (13 GB). The query set is available <a href="./queries-sisap.tar">queries-sisap.tar</a> (8 GB) as well. The algorithms used the following parameter choices in the experiments: <a href="./algos.yaml">k = 10</a> and <a href="./algos100.yaml">k=100</a>.</p>
             <div id="contact">
             <h2>Contact</h2>
             <p>ANN-Benchmarks has been developed by Martin Aumueller (maau@itu.dk), Erik Bernhardsson (mail@erikbern.com), and Alec Faitfull (alef@itu.dk). Please use

--- a/install.py
+++ b/install.py
@@ -9,7 +9,10 @@ client.images.build(path=os.getcwd(), tag='ann-benchmarks', rm=True, dockerfile=
 
 def build(library):
     print('Building %s...' % library)
-    client.images.build(path=os.getcwd(), tag='ann-benchmarks-%s' % library, rm=True, dockerfile='install/Dockerfile.%s' % library)
+    try:
+        client.images.build(path=os.getcwd(), tag='ann-benchmarks-%s' % library, rm=True, dockerfile='install/Dockerfile.%s' % library)
+    except docker.errors.BuildError as err:
+        print("Build error: {0}".format(err))
 
 if os.getenv('LIBRARY'):
     build(os.getenv('LIBRARY'))

--- a/plot.py
+++ b/plot.py
@@ -95,11 +95,12 @@ if __name__ == "__main__":
     dimension = len(dataset['train'][0]) # TODO(erikbern): ugly
     point_type = 'float' # TODO(erikbern): should look at the type of X_train
     distance = dataset.attrs['distance']
-    definitions = get_definitions(args.definitions, dimension, point_type, distance, args.count)
+    count = int(args.count)
+    definitions = get_definitions(args.definitions, dimension, point_type, distance, count)
     unique_algorithms = get_unique_algorithms(args.definitions)
     linestyles = create_linestyles(unique_algorithms)
-    results = load_results(args.dataset, args.count, definitions)
-    runs = compute_metrics(dataset, results, args.count, args.x_axis, args.y_axis)
+    results = load_results(args.dataset, count, definitions)
+    runs = compute_metrics(dataset, results, count, args.x_axis, args.y_axis)
 
     create_plot(runs, args.raw, args.x_log,
             args.y_log, args.x_axis, args.y_axis, args.output, linestyles)

--- a/plot.py
+++ b/plot.py
@@ -99,7 +99,7 @@ if __name__ == "__main__":
     unique_algorithms = get_unique_algorithms(args.definitions)
     linestyles = create_linestyles(unique_algorithms)
     results = load_results(args.dataset, args.count, definitions)
-    runs = compute_metrics(dataset, results, args.x_axis, args.y_axis)
+    runs = compute_metrics(dataset, results, args.count, args.x_axis, args.y_axis)
 
     create_plot(runs, args.raw, args.x_log,
             args.y_log, args.x_axis, args.y_axis, args.output, linestyles)

--- a/plot.py
+++ b/plot.py
@@ -100,7 +100,7 @@ if __name__ == "__main__":
     unique_algorithms = get_unique_algorithms(args.definitions)
     linestyles = create_linestyles(unique_algorithms)
     results = load_results(args.dataset, count, definitions)
-    runs = compute_metrics(dataset, results, count, args.x_axis, args.y_axis)
+    runs = compute_metrics(list(dataset["distances"]), results, args.x_axis, args.y_axis)
 
     create_plot(runs, args.raw, args.x_log,
             args.y_log, args.x_axis, args.y_axis, args.output, linestyles)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ pyyaml==3.12
 psutil==5.4.2
 scipy==1.0.0
 scikit-learn==0.19.1
+jinja2=2.10

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ numpy==1.13.3
 pyyaml==3.12
 psutil==5.4.2
 scipy==1.0.0
+scikit-learn==0.19.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ pyyaml==3.12
 psutil==5.4.2
 scipy==1.0.0
 scikit-learn==0.19.1
-jinja2=2.10
+jinja2==2.10

--- a/templates/chartjs.template
+++ b/templates/chartjs.template
@@ -1,0 +1,102 @@
+            <h3>{{xlabel}}/{{ylabel}}</h3>
+            <div id="{{ xlabel }}{{ ylabel }}{{ label }}">
+            <canvas id="chart{{ xlabel }}{{ ylabel }}{{ label }}" width="800" height="600"></canvas>
+            <script>
+                var ctx = document.getElementById("chart{{ xlabel }}{{ ylabel }}{{ label }}");
+                var chart = new Chart(ctx, {
+                    {% if not render_all_points %}
+                    type: "line",
+                    {% else %}
+                    type: "bubble",
+                    {% endif %}
+                    data: { datasets: [
+                        {% for run in data_points %}
+                        {
+                            label: "{{ run["name"] }}",
+                            fill: false,
+                            pointStyle: "{{ linestyle[run["name"]][3] }}",
+                            borderColor: "{{ linestyle[run["name"]][0] }}",
+                            data: [
+                                {% for (x, y), l in zip(run["coords"], run["labels"]) %}
+                                    { x: {{ x }} , y: {{ y }}, label: "{{ l }}" },
+                                {% endfor %}
+                            ]
+                        },
+                        {% endfor %}
+                        ]},
+                        options: {
+                            responsive: false,
+                            title:{
+                                display:true,
+                                text: '{{ plot_label }}'
+                            },
+                            scales: {
+                                xAxes: [{
+                                    display: true,
+                                    type: 'linear',
+                                    max: '1',
+                                    position: 'bottom',
+                                    scaleLabel: {
+                                        display: true,
+                                        labelString: ' {{ xlabel }}   '
+                                    }
+                                }],
+                                yAxes: [{
+                                    display: true,
+                                    type: 'logarithmic',
+                                    scaleLabel: {
+                                        display: true,
+                                        labelString: ' {{ ylabel }} '
+                                    }
+                                }]
+                            }
+                        }
+                    });
+                function pushOrConcat(base, toPush) {
+                        if (toPush) {
+                                if (Chart.helpers.isArray(toPush)) {
+                                        // base = base.concat(toPush);
+                                        Array.prototype.push.apply(base, toPush);
+                                } else {
+                                        base.push(toPush);
+                                }
+                        }
+
+                        return base;
+                }
+                Chart.Tooltip.prototype.getFooter = function(tooltipItem, data) {
+                    var me = this;
+                    var callbacks = me._options.callbacks;
+                    var item = tooltipItem[0];
+
+                    var beforeFooter = callbacks.beforeFooter.apply(me, arguments);
+                    var footer = "Parameters: " + data.datasets[item.datasetIndex].data[item.index].label || '';
+                    var afterFooter = callbacks.afterFooter.apply(me, arguments);
+
+                    var lines = [];
+                    lines = pushOrConcat(lines, beforeFooter);
+                    lines = pushOrConcat(lines, footer);
+                    lines = pushOrConcat(lines, afterFooter);
+
+                    return lines;
+                }
+
+                </script>
+            </div>
+            {% if args.latex %}
+                <div class="row">
+                    <div class="col-md-4 text-center">
+                        <button type="button" id="button_{{button_label}}" class="btn btn-default" >Toggle latex code</button>
+                    </div>
+                </div>
+                <script>
+                    $("#button_{{button_label}}").click(function() {
+                        $("#plot_{{button_label}}").toggle();
+                    });
+                </script>
+                <div id="plot_{{button_label}}" style="display:none">
+                    <pre>
+                    {{latex_code}}
+                    </pre>
+                </div>
+            {% endif %}

--- a/templates/detail_page.html
+++ b/templates/detail_page.html
@@ -1,0 +1,183 @@
+{% extends "general.html" %}
+{% block content %}
+        <div class="container">
+            <h2>Plots for {{title}}</h2>
+            {% for plot in plot_data["normal"] %}
+            <h3>{{plot.xlabel}}/{{plot.ylabel}}</h3>
+        <div id="{{ plot.xlabel }}{{ plot.ylabel }}{{ plot.label }}">
+            <canvas id="chart{{ plot.xlabel }}{{ plot.ylabel }}{{ plot.label }}" width="800" height="600"></canvas>
+            <script>
+                var ctx = document.getElementById("chart{{ plot.xlabel }}{{ plot.ylabel }}{{ plot.label }}");
+                var chart = new Chart(ctx, {
+                    type: "{{ plot.plottype }}",
+                    data: { datasets: [{{ plot.datapoints}}
+                        ]},
+                        options: {
+                            responsive: false,
+                            title:{
+                                display:true,
+                                text: '{{ plot.plotlabel }}'
+                            },
+                            scales: {
+                                xAxes: [{
+                                    display: true,
+                                    type: 'linear',
+                                    max: '1',
+                                    position: 'bottom',
+                                    scaleLabel: {
+                                        display: true,
+                                        labelString: ' {{ plot.xlabel }}   '
+                                    }
+                                }],
+                                yAxes: [{
+                                    display: true,
+                                    type: 'logarithmic',
+                                    scaleLabel: {
+                                        display: true,
+                                        labelString: ' {{ plot.ylabel }} '
+                                    }
+                                }]
+                            }
+                        }
+                    });
+                function pushOrConcat(base, toPush) {
+                        if (toPush) {
+                                if (Chart.helpers.isArray(toPush)) {
+                                        // base = base.concat(toPush);
+                                        Array.prototype.push.apply(base, toPush);
+                                } else {
+                                        base.push(toPush);
+                                }
+                        }
+
+                        return base;
+                }
+                Chart.Tooltip.prototype.getFooter = function(tooltipItem, data) {
+                    var me = this;
+                    var callbacks = me._options.callbacks;
+                    var item = tooltipItem[0];
+
+                    var beforeFooter = callbacks.beforeFooter.apply(me, arguments);
+                    var footer = "Parameters: " + data.datasets[item.datasetIndex].data[item.index].label || '';
+                    var afterFooter = callbacks.afterFooter.apply(me, arguments);
+
+                    var lines = [];
+                    lines = pushOrConcat(lines, beforeFooter);
+                    lines = pushOrConcat(lines, footer);
+                    lines = pushOrConcat(lines, afterFooter);
+
+                    return lines;
+                }
+
+                </script>
+            </div>
+            {% if args.latex %}
+                <div class="row">
+                    <div class="col-md-4 text-center">
+                        <button type="button" id="button_{{plot.buttonlabel}}" class="btn btn-default" >Toggle latex code</button>
+                    </div>
+                </div>
+                <script>
+                    $("#button_{{plot.buttonlabel}}").click(function() {
+                        $("#plot_{{plot.buttonlabel}}").toggle();
+                    });
+                </script>
+                <div id="plot_{{plot.buttonlabel}}" style="display:none">
+                    <pre>
+                    {{plot.latexcode}}
+                    </pre>
+                </div>
+            {% endif %}
+            {% endfor %}
+    {% if args.scatter %}
+            <hr />
+            <h2>Scatterplots for {{title}}</h2>
+            {% for plot in plot_data["scatter"] %}
+            <h3>{{plot.xlabel}}/{{plot.ylabel}}</h3>
+        <div id="{{ plot.xlabel }}{{ plot.ylabel }}{{ plot.label }}">
+            <canvas id="chart{{ plot.xlabel }}{{ plot.ylabel }}{{ plot.label }}" width="800" height="600"></canvas>
+            <script>
+                var ctx = document.getElementById("chart{{ plot.xlabel }}{{ plot.ylabel }}{{ plot.label }}");
+                var chart = new Chart(ctx, {
+                    type: "{{ plot.plottype }}",
+                    data: { datasets: [{{ plot.datapoints}}
+                        ]},
+                        options: {
+                            responsive: false,
+                            title:{
+                                display:true,
+                                text: '{{ plot.plotlabel }}'
+                            },
+                            scales: {
+                                xAxes: [{
+                                    display: true,
+                                    type: 'linear',
+                                    max: '1',
+                                    position: 'bottom',
+                                    scaleLabel: {
+                                        display: true,
+                                        labelString: ' {{ plot.xlabel }}   '
+                                    }
+                                }],
+                                yAxes: [{
+                                    display: true,
+                                    type: 'logarithmic',
+                                    scaleLabel: {
+                                        display: true,
+                                        labelString: ' {{ plot.ylabel }} '
+                                    }
+                                }]
+                            }
+                        }
+                    });
+                function pushOrConcat(base, toPush) {
+                        if (toPush) {
+                                if (Chart.helpers.isArray(toPush)) {
+                                        // base = base.concat(toPush);
+                                        Array.prototype.push.apply(base, toPush);
+                                } else {
+                                        base.push(toPush);
+                                }
+                        }
+
+                        return base;
+                }
+                Chart.Tooltip.prototype.getFooter = function(tooltipItem, data) {
+                    var me = this;
+                    var callbacks = me._options.callbacks;
+                    var item = tooltipItem[0];
+
+                    var beforeFooter = callbacks.beforeFooter.apply(me, arguments);
+                    var footer = "Parameters: " + data.datasets[item.datasetIndex].data[item.index].label || '';
+                    var afterFooter = callbacks.afterFooter.apply(me, arguments);
+
+                    var lines = [];
+                    lines = pushOrConcat(lines, beforeFooter);
+                    lines = pushOrConcat(lines, footer);
+                    lines = pushOrConcat(lines, afterFooter);
+
+                    return lines;
+                }
+
+                </script>
+            </div>
+            {% if args.latex %}
+                <div class="row">
+                    <div class="col-md-4 text-center">
+                        <button type="button" id="button_{{plot.buttonlabel}}" class="btn btn-default" >Toggle latex code</button>
+                    </div>
+                </div>
+                <script>
+                    $("#button_{{plot.buttonlabel}}").click(function() {
+                        $("#plot_{{plot.buttonlabel}}").toggle();
+                    });
+                </script>
+                <div id="plot_{{plot.buttonlabel}}" style="display:none">
+                    <pre>
+                    {{plot.latexcode}}
+                    </pre>
+                </div>
+            {% endif %}
+            {% endfor %}
+    {% endif %}
+{% endblock %}

--- a/templates/detail_page.html
+++ b/templates/detail_page.html
@@ -4,99 +4,11 @@
         {% for item in plot_data.keys() %}
             {% if item=="normal" %}
             <h2>Plots for {{title}}</h2>
-            {% elif item=="scatter" %}
+            {% elif item=="scatter" and args.scatter %}
             <h2>Scatterplots for {{title}}</h2>
             {% endif %}
             {% for plot in plot_data[item] %}
-            <h3>{{plot.xlabel}}/{{plot.ylabel}}</h3>
-            <div id="{{ plot.xlabel }}{{ plot.ylabel }}{{ plot.label }}">
-            <canvas id="chart{{ plot.xlabel }}{{ plot.ylabel }}{{ plot.label }}" width="800" height="600"></canvas>
-            <script>
-                var ctx = document.getElementById("chart{{ plot.xlabel }}{{ plot.ylabel }}{{ plot.label }}");
-                var chart = new Chart(ctx, {
-                    {% if item == "normal" %}
-                    type: "line",
-                    {% elif item == "scatter" %}
-                    type: "bubble",
-                    {% endif %}
-                    data: { datasets: [{{ plot.datapoints}}
-                        ]},
-                        options: {
-                            responsive: false,
-                            title:{
-                                display:true,
-                                text: '{{ plot.plotlabel }}'
-                            },
-                            scales: {
-                                xAxes: [{
-                                    display: true,
-                                    type: 'linear',
-                                    max: '1',
-                                    position: 'bottom',
-                                    scaleLabel: {
-                                        display: true,
-                                        labelString: ' {{ plot.xlabel }}   '
-                                    }
-                                }],
-                                yAxes: [{
-                                    display: true,
-                                    type: 'logarithmic',
-                                    scaleLabel: {
-                                        display: true,
-                                        labelString: ' {{ plot.ylabel }} '
-                                    }
-                                }]
-                            }
-                        }
-                    });
-                function pushOrConcat(base, toPush) {
-                        if (toPush) {
-                                if (Chart.helpers.isArray(toPush)) {
-                                        // base = base.concat(toPush);
-                                        Array.prototype.push.apply(base, toPush);
-                                } else {
-                                        base.push(toPush);
-                                }
-                        }
-
-                        return base;
-                }
-                Chart.Tooltip.prototype.getFooter = function(tooltipItem, data) {
-                    var me = this;
-                    var callbacks = me._options.callbacks;
-                    var item = tooltipItem[0];
-
-                    var beforeFooter = callbacks.beforeFooter.apply(me, arguments);
-                    var footer = "Parameters: " + data.datasets[item.datasetIndex].data[item.index].label || '';
-                    var afterFooter = callbacks.afterFooter.apply(me, arguments);
-
-                    var lines = [];
-                    lines = pushOrConcat(lines, beforeFooter);
-                    lines = pushOrConcat(lines, footer);
-                    lines = pushOrConcat(lines, afterFooter);
-
-                    return lines;
-                }
-
-                </script>
-            </div>
-            {% if args.latex %}
-                <div class="row">
-                    <div class="col-md-4 text-center">
-                        <button type="button" id="button_{{plot.buttonlabel}}" class="btn btn-default" >Toggle latex code</button>
-                    </div>
-                </div>
-                <script>
-                    $("#button_{{plot.buttonlabel}}").click(function() {
-                        $("#plot_{{plot.buttonlabel}}").toggle();
-                    });
-                </script>
-                <div id="plot_{{plot.buttonlabel}}" style="display:none">
-                    <pre>
-                    {{plot.latexcode}}
-                    </pre>
-                </div>
-            {% endif %}
+            {{ plot }}
             {% endfor %}
             <hr />
         {% endfor %}

--- a/templates/detail_page.html
+++ b/templates/detail_page.html
@@ -1,105 +1,24 @@
 {% extends "general.html" %}
 {% block content %}
         <div class="container">
+        {% for item in plot_data.keys() %}
+            {% if item=="normal" %}
             <h2>Plots for {{title}}</h2>
-            {% for plot in plot_data["normal"] %}
-            <h3>{{plot.xlabel}}/{{plot.ylabel}}</h3>
-        <div id="{{ plot.xlabel }}{{ plot.ylabel }}{{ plot.label }}">
-            <canvas id="chart{{ plot.xlabel }}{{ plot.ylabel }}{{ plot.label }}" width="800" height="600"></canvas>
-            <script>
-                var ctx = document.getElementById("chart{{ plot.xlabel }}{{ plot.ylabel }}{{ plot.label }}");
-                var chart = new Chart(ctx, {
-                    type: "{{ plot.plottype }}",
-                    data: { datasets: [{{ plot.datapoints}}
-                        ]},
-                        options: {
-                            responsive: false,
-                            title:{
-                                display:true,
-                                text: '{{ plot.plotlabel }}'
-                            },
-                            scales: {
-                                xAxes: [{
-                                    display: true,
-                                    type: 'linear',
-                                    max: '1',
-                                    position: 'bottom',
-                                    scaleLabel: {
-                                        display: true,
-                                        labelString: ' {{ plot.xlabel }}   '
-                                    }
-                                }],
-                                yAxes: [{
-                                    display: true,
-                                    type: 'logarithmic',
-                                    scaleLabel: {
-                                        display: true,
-                                        labelString: ' {{ plot.ylabel }} '
-                                    }
-                                }]
-                            }
-                        }
-                    });
-                function pushOrConcat(base, toPush) {
-                        if (toPush) {
-                                if (Chart.helpers.isArray(toPush)) {
-                                        // base = base.concat(toPush);
-                                        Array.prototype.push.apply(base, toPush);
-                                } else {
-                                        base.push(toPush);
-                                }
-                        }
-
-                        return base;
-                }
-                Chart.Tooltip.prototype.getFooter = function(tooltipItem, data) {
-                    var me = this;
-                    var callbacks = me._options.callbacks;
-                    var item = tooltipItem[0];
-
-                    var beforeFooter = callbacks.beforeFooter.apply(me, arguments);
-                    var footer = "Parameters: " + data.datasets[item.datasetIndex].data[item.index].label || '';
-                    var afterFooter = callbacks.afterFooter.apply(me, arguments);
-
-                    var lines = [];
-                    lines = pushOrConcat(lines, beforeFooter);
-                    lines = pushOrConcat(lines, footer);
-                    lines = pushOrConcat(lines, afterFooter);
-
-                    return lines;
-                }
-
-                </script>
-            </div>
-            {% if args.latex %}
-                <div class="row">
-                    <div class="col-md-4 text-center">
-                        <button type="button" id="button_{{plot.buttonlabel}}" class="btn btn-default" >Toggle latex code</button>
-                    </div>
-                </div>
-                <script>
-                    $("#button_{{plot.buttonlabel}}").click(function() {
-                        $("#plot_{{plot.buttonlabel}}").toggle();
-                    });
-                </script>
-                <div id="plot_{{plot.buttonlabel}}" style="display:none">
-                    <pre>
-                    {{plot.latexcode}}
-                    </pre>
-                </div>
-            {% endif %}
-            {% endfor %}
-    {% if args.scatter %}
-            <hr />
+            {% elif item=="scatter" %}
             <h2>Scatterplots for {{title}}</h2>
-            {% for plot in plot_data["scatter"] %}
+            {% endif %}
+            {% for plot in plot_data[item] %}
             <h3>{{plot.xlabel}}/{{plot.ylabel}}</h3>
-        <div id="{{ plot.xlabel }}{{ plot.ylabel }}{{ plot.label }}">
+            <div id="{{ plot.xlabel }}{{ plot.ylabel }}{{ plot.label }}">
             <canvas id="chart{{ plot.xlabel }}{{ plot.ylabel }}{{ plot.label }}" width="800" height="600"></canvas>
             <script>
                 var ctx = document.getElementById("chart{{ plot.xlabel }}{{ plot.ylabel }}{{ plot.label }}");
                 var chart = new Chart(ctx, {
-                    type: "{{ plot.plottype }}",
+                    {% if item == "normal" %}
+                    type: "line",
+                    {% elif item == "scatter" %}
+                    type: "bubble",
+                    {% endif %}
                     data: { datasets: [{{ plot.datapoints}}
                         ]},
                         options: {
@@ -179,5 +98,6 @@
                 </div>
             {% endif %}
             {% endfor %}
-    {% endif %}
+            <hr />
+        {% endfor %}
 {% endblock %}

--- a/templates/general.html
+++ b/templates/general.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+    <html lang="en">
+      <head>
+        <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
+        <title>{{ title }}</title>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.5.0/Chart.js"></script>
+        <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
+        <!-- Include all compiled plugins (below), or include individual files as needed -->
+        <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+        <!-- Bootstrap -->
+        <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+        <style>
+            body { padding-top: 50px; }
+        </style>
+        <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
+        <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
+        <!--[if lt IE 9]>
+          <script src="https://oss.maxcdn.com/html5shiv/3.7.3/html5shiv.min.js"></script>
+          <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
+        <![endif]-->
+      </head>
+         <body>
+
+            <nav class="navbar navbar-inverse navbar-fixed-top">
+              <div class="container">
+                <div class="navbar-header">
+                  <a class="navbar-brand" href="index.html">ANN Benchmarks</a>
+                </div>
+                <div id="navbar" class="collapse navbar-collapse">
+                  <ul class="nav navbar-nav">
+                    <li class="active"><a href="index.html">Home</a></li>
+                  </ul>
+                  <ul class="nav navbar-nav">
+                    <li class="active"><a href="index.html#datasets">Datasets</a></li>
+                  </ul>
+                  <ul class="nav navbar-nav">
+                    <li class="active"><a href="index.html#algorithms">Algorithms</a></li>
+                  </ul>
+                  <ul class="nav navbar-nav">
+                    <li class="active"><a href="index.html#contact">Contact</a></li>
+                  </ul>
+                </div><!--/.nav-collapse -->
+              </div>
+            </nav>
+
+            {% block content %} {% endblock %}
+
+            <div id="contact">
+            <h2>Contact</h2>
+            <p>ANN-Benchmarks has been developed by Martin Aumueller (maau@itu.dk), Erik Bernhardsson (mail@erikbern.com), and Alec Faitfull (alef@itu.dk). Please use
+            <a href="https://github.com/erikbern/ann-benchmarks/">Github</a> to submit your implementation or improvements.</p>
+            </div>
+        </div>
+    </body>
+</html>

--- a/templates/latex.template
+++ b/templates/latex.template
@@ -1,0 +1,30 @@
+
+\begin{figure}
+    \centering
+    \begin{tikzpicture}
+        \begin{axis}[
+            xlabel={ {{xlabel}} },
+            ylabel={ {{ylabel}} },
+            ymode = log,
+            yticklabel style={/pgf/number format/fixed,
+                              /pgf/number format/precision=3},
+            legend style = { anchor=west},
+            cycle list name = black white
+            ]
+        {% for algo in plot_data %}
+            {% if algo.scatter %} 
+            \addplot [only marks] coordinates {
+            {% else %}
+            \addplot coordinates {
+            {% endif %}
+                {% for coord in algo.coords %} 
+                    ({{ coord[0]}}, {{ coord[1] }})
+                {% endfor %}
+            }
+            \addlegendentry{ {{algo.name}} };
+        {% endfor %}
+    \end{axis}
+    \end{tikzpicture}
+    \caption{ {{caption}} }
+    \label{}
+\end{figure}

--- a/templates/latex.template
+++ b/templates/latex.template
@@ -12,15 +12,15 @@
             cycle list name = black white
             ]
         {% for algo in plot_data %}
-            {% if algo.scatter %} 
+            {% if algo.scatter %}
             \addplot [only marks] coordinates {
             {% else %}
             \addplot coordinates {
             {% endif %}
-                {% for coord in algo.coords %} 
+                {% for coord in algo.coords %}
                     ({{ coord[0]}}, {{ coord[1] }})
                 {% endfor %}
-            }
+            };
             \addlegendentry{ {{algo.name}} };
         {% endfor %}
     \end{axis}

--- a/templates/summary.html
+++ b/templates/summary.html
@@ -1,0 +1,50 @@
+{% extends "general.html" %}
+{% block content %}
+        <div class="container">
+            <h1>Info</h1>
+            <p>ANN-Benchmarks is a benchmarking environment for approximate nearest neighbor algorithms search. This website contains the current benchmarking results. Please visit <a href="http://github.com/erikbern/ann-benchmarks/">http://github.com/erikbern/ann-benchmarks/</a> to get an overview over evaluated data sets and algorithms. Make a pull request on <a href="http://github.com/erikbern/ann-benchmarks/">Github</a> to add your own code or improvements to the
+            benchmarking system.
+            </p>
+            <div id="results">
+            <h1>Benchmarking Results</h1>
+            <p>Results are split by distance measure and dataset. In the bottom, you can find an overview of an algorithm's performance on all datasets. Each dataset is annoted
+            by <em>(k = ...)</em>, the number of nearest neighbors an algorithm was supposed to return. The plot shown depicts <em>Recall</em> (the fraction
+            of true nearest neighbors found, on average over all queries) against <em>Queries per second</em>.  Clicking on a plot reveils detailled interactive plots, including
+            approximate recall, index size, and build time.</p>
+            <h2 id ="datasets">Results by Dataset</h2>
+            {% for distance_data in dataset_with_distances %}
+                <h3>Distance: {{ distance_data.name }} </h3>
+                {% for entry in distance_data.entries %}
+                <a href="./{{entry.name}}.html">
+                    <div class="row" id="{{entry.name}}">
+                        <div class = "col-md-4 bg-success">
+                            <h4>{{entry.desc}}</h4>
+                    </div>
+                    <div class = "col-md-8">
+                        <img class = "img-responsive" src="{{entry.name}}.png" />
+                    </div>
+                </div>
+                </a>
+                <hr />
+                {% endfor %}
+            {% endfor %}
+            <h2 id="algorithms">Results by Algorithm</h2>
+            <ul class="list-inline"><b>Algorithms:</b>
+                {% for algo in algorithms %}
+                <li><a href="#{{algo}}">{{algo}}</a></li>
+                {% endfor %}
+            </ul>
+            {% for algo in algorithms%}
+            <a href="./{{algo}}.html">
+                <div class="row" id="{{algo}}">
+                    <div class = "col-md-4 bg-success">
+                        <h4>{{algo}}</h4>
+                </div>
+                <div class = "col-md-8">
+                    <img class = "img-responsive" src="{{algo}}.png" />
+                </div>
+            </div>
+            </a>
+            <hr />
+            {% endfor %}
+{% endblock %}

--- a/test/test-metrics.py
+++ b/test/test-metrics.py
@@ -1,0 +1,63 @@
+import unittest
+from ann_benchmarks.plotting.metrics import knn, queries_per_second,\
+        index_size, build_time, candidates, epsilon, rel
+
+class TestMetrics(unittest.TestCase):
+
+    def setUp(self):
+        pass
+
+    def test_recall(self):
+        exact_queries = [[0.1, 0.25]]
+        run1 = [[]]
+        run2 = [[0.2, 0.3]]
+        run3 = [[0.2]]
+        run4 = [[0.2, 0.25]]
+
+        self.assertAlmostEqual(knn(exact_queries, run1, 2), 0.0)
+        self.assertAlmostEqual(knn(exact_queries, run2, 2), 0.5)
+        self.assertAlmostEqual(knn(exact_queries, run3, 2), 0.5)
+        self.assertAlmostEqual(knn(exact_queries, run4, 2), 1.0)
+
+    def test_epsilon_recall(self):
+        exact_queries = [[0.05, 0.08, 0.24, 0.3]]
+        run1 = [[]]
+        run2 = [[0.1, 0.2, 0.55, 0.7]]
+
+        self.assertAlmostEqual(epsilon(exact_queries, run1, 4, 1), 0.0)
+
+        self.assertAlmostEqual(epsilon(exact_queries, run2, 4, 0.0001), 0.5)
+        # distance can be off by factor (1 + 1) * 0.3 = 0.6 => recall .75
+        self.assertAlmostEqual(epsilon(exact_queries, run2, 4, 1), 0.75)
+        # distance can be off by factor (1 + 2) * 0.3 = 0.9 => recall 1
+        self.assertAlmostEqual(epsilon(exact_queries, run2, 4, 2), 1.0)
+
+    def test_relative(self):
+        exact_queries = [[0.1, 0.2, 0.25, 0.3]]
+        run1 = []
+        run2 = [[0.1, 0.2, 0.25, 0.3]]
+        run3 = [[0.1, 0.2, 0.55, 0.9]]
+
+        self.assertAlmostEqual(rel(exact_queries, run1), float("inf"))
+        self.assertAlmostEqual(rel(exact_queries, run2), 1)
+        # total distance exact: 0.85, total distance run3: 1.75
+        self.assertAlmostEqual(rel(exact_queries, run3), 1.75 /
+                0.85)
+
+    def test_queries_per_second(self):
+        self.assertAlmostEqual(queries_per_second([], {"best_search_time" : 0.01}),
+                100)
+
+    def test_index_size(self):
+        self.assertEqual(index_size([], {"index_size" : 100}), 100)
+
+    def test_build_time(self):
+        self.assertEqual(build_time([], {"build_time" : 100}), 100)
+
+    def test_candidates(self):
+        self.assertEqual(candidates([], {"candidates" : 10}), 10)
+
+
+if __name__ == '__main__':
+    unittest.main()
+


### PR DESCRIPTION
This PR adds back support for running `createwebsite.py`. This script builds a website containing interactive plots for all results that are stored. Enabling support for this resulted in some questionable choices after #54. In particular, 

- Needed to add auxiliary helpers to load all the results. It's not a lot of code, but it seems hard to maintain with other parts of code such as `get_result_filename`.
- Needed to convert a lot of data, because the plotting utils now always assume an `x` and `y` value; however, generating all the plots uses a dict from which we can read of the `x` and `y` values. This is really going to hurt performance of the script for large result repositories.

In general, `create_website.py` is a monolithic beast because of all the html output that is stored directly in it. I'd welcome comments on how to improve it (using some template engine?).

On the way, I decoupled some details of the metric computation from the file format that is now used. That made it possible to provide some unit tests for the metric computation, that I felt should be in place also for documentation reasons. 

In general, since the change to the hdf5 file format, plotting became _horribly slow_. It's about 20 times slower for similar result files than the previous version that stored everything in JSON and used a different format. I feel the need that we really have to make this part more efficient. 