### PR TITLE
Skip missing algorithms in local mode

### DIFF
--- a/ann_benchmarks/algorithms/definitions.py
+++ b/ann_benchmarks/algorithms/definitions.py
@@ -8,6 +8,7 @@ import re
 import sys
 import traceback
 import yaml
+from enum import Enum
 from itertools import product
 
 
@@ -20,6 +21,20 @@ def instantiate_algorithm(definition):
     constructor = getattr(module, definition.constructor)
     return constructor(*definition.arguments)
 
+class InstantiationStatus(Enum):
+    AVAILABLE = 0
+    NO_CONSTRUCTOR = 1
+    NO_MODULE = 2
+
+def algorithm_status(definition):
+    try:
+        module = importlib.import_module(definition.module)
+        if hasattr(module, definition.constructor):
+            return InstantiationStatus.AVAILABLE
+        else:
+            return InstantiationStatus.NO_CONSTRUCTOR
+    except ImportError:
+        return InstantiationStatus.NO_MODULE
 
 def get_result_filename(dataset, count, definition):
     d = ['results',

--- a/ann_benchmarks/main.py
+++ b/ann_benchmarks/main.py
@@ -90,14 +90,6 @@ def main():
         list_algorithms(args.definitions)
         sys.exit(0)
 
-    # See which Docker images we have available
-    docker_client = docker.from_env()
-    docker_tags = set()
-    for image in docker_client.images.list():
-        for tag in image.tags:
-            tag, _ = tag.split(':')
-            docker_tags.add(tag)
-
     # Nmslib specific code
     # Remove old indices stored on disk
     if os.path.exists(INDEX_DIR):
@@ -119,6 +111,14 @@ def main():
         definitions = [d for d in definitions if d.algorithm == args.algorithm]
 
     if not args.local:
+        # See which Docker images we have available
+        docker_client = docker.from_env()
+        docker_tags = set()
+        for image in docker_client.images.list():
+            for tag in image.tags:
+                tag, _ = tag.split(':')
+                docker_tags.add(tag)
+
         if args.docker_tag:
             print('running only', args.docker_tag)
             definitions = [d for d in definitions if d.docker_tag == args.docker_tag]

--- a/ann_benchmarks/main.py
+++ b/ann_benchmarks/main.py
@@ -138,8 +138,8 @@ def main():
                 # If the module couldn't be loaded (presumably because of a missing
                 # dependency), print a warning and remove this definition from the
                 # list of things to be run
-                print """\
-%s.%s(%s): warning: the module '%s' could not be loaded; skipping""" % (df.module, df.constructor, df.arguments, df.module)
+                print("""\
+%s.%s(%s): warning: the module '%s' could not be loaded; skipping""" % (df.module, df.constructor, df.arguments, df.module))
                 return False
             else:
                 return True

--- a/ann_benchmarks/main.py
+++ b/ann_benchmarks/main.py
@@ -9,7 +9,7 @@ import traceback
 
 from ann_benchmarks.datasets import get_dataset, DATASETS
 from ann_benchmarks.constants import INDEX_DIR
-from ann_benchmarks.algorithms.definitions import get_definitions, list_algorithms, get_result_filename
+from ann_benchmarks.algorithms.definitions import get_definitions, list_algorithms, get_result_filename, algorithm_status, InstantiationStatus
 from ann_benchmarks.runner import run, run_docker
 
 
@@ -118,14 +118,32 @@ def main():
         print('running only', args.algorithm)
         definitions = [d for d in definitions if d.algorithm == args.algorithm]
 
-    if args.docker_tag:
-        print('running only', args.docker_tag)
-        definitions = [d for d in definitions if d.docker_tag == args.docker_tag]
+    if not args.local:
+        if args.docker_tag:
+            print('running only', args.docker_tag)
+            definitions = [d for d in definitions if d.docker_tag == args.docker_tag]
 
-    if set(d.docker_tag for d in definitions).difference(docker_tags):
-        print('not all docker images available, only:', set(docker_tags))
-        print('missing docker images:', set(d.docker_tag for d in definitions).difference(docker_tags))
-        definitions = [d for d in definitions if d.docker_tag in docker_tags]
+        if set(d.docker_tag for d in definitions).difference(docker_tags):
+            print('not all docker images available, only:', set(docker_tags))
+            print('missing docker images:', set(d.docker_tag for d in definitions).difference(docker_tags))
+            definitions = [d for d in definitions if d.docker_tag in docker_tags]
+    else:
+        def _test(df):
+            status = algorithm_status(df)
+            # If the module was loaded but doesn't actually have a constructor of
+            # the right name, then the definition is broken
+            assert status != InstantiationStatus.NO_CONSTRUCTOR, """\
+%s.%s(%s): error: the module '%s' does not expose the named constructor""" % (df.module, df.constructor, df.arguments, df.module)
+            if status == InstantiationStatus.NO_MODULE:
+                # If the module couldn't be loaded (presumably because of a missing
+                # dependency), print a warning and remove this definition from the
+                # list of things to be run
+                print """\
+%s.%s(%s): warning: the module '%s' could not be loaded; skipping""" % (df.module, df.constructor, df.arguments, df.module)
+                return False
+            else:
+                return True
+        definitions = [d for d in definitions if _test(d)]
 
     if args.max_n_algorithms >= 0:
         definitions = definitions[:args.max_n_algorithms]

--- a/install/Dockerfile.faiss
+++ b/install/Dockerfile.faiss
@@ -8,5 +8,5 @@ ENV PYTHONPATH lib-faiss
 # faiss doesn't work with python3 afaik
 RUN python -c 'import faiss'
 RUN pip install -rrequirements.txt
-RUN pip install sklearn
+RUN pip install sklearn enum34
 ENTRYPOINT ["python", "run_algorithm.py"]

--- a/install/Dockerfile.kgraph
+++ b/install/Dockerfile.kgraph
@@ -7,4 +7,5 @@ RUN cd kgraph && python setup.py build && python setup.py install
 # kgraph doesn't work with python3 afaik
 RUN python -c 'import pykgraph'
 RUN pip install -rrequirements.txt
+RUN pip install enum34
 ENTRYPOINT ["python", "run_algorithm.py"]

--- a/install/Dockerfile.nmslib
+++ b/install/Dockerfile.nmslib
@@ -12,4 +12,5 @@ RUN cd nmslib/python_bindings && python setup.py install
 # nmslib doesn't work with python3 afaik
 RUN python -c 'import nmslib'
 RUN pip install -rrequirements.txt
+RUN pip install enum34
 ENTRYPOINT ["python", "run_algorithm.py"]

--- a/install/Dockerfile.panns
+++ b/install/Dockerfile.panns
@@ -6,4 +6,5 @@ RUN pip install panns
 # panns doesn't work with python3 afaik
 RUN python -c 'import panns'
 RUN pip install -rrequirements.txt
+RUN pip install enum34
 ENTRYPOINT ["python", "run_algorithm.py"]


### PR DESCRIPTION
Here's a minor fix for local mode that lets the framework skip over missing algorithms. (Commit 70836ecca6c6649fe91dc678ea1b790b682cde42 added this, but only for Docker mode.)