### PR TITLE
disable panns, nearpy, faiss-lsh, dolphinn

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ before_install:
   - python install.py
 
 script:
-  - python run.py --docker-tag ann-benchmarks-${LIBRARY} --max-n-algorithms 5 --dataset random-xs-20-angular
+  - python run.py --docker-tag ann-benchmarks-${LIBRARY} --max-n-algorithms 5 --dataset random-xs-20-angular --run-disabled
   - python plot.py --dataset random-xs-20-angular --output plot.png
   - python -m unittest test/test-metrics.py
   - python create_website.py --outputdir . --scatter --latex

--- a/algos.yaml
+++ b/algos.yaml
@@ -1,6 +1,7 @@
 float:
   any:
     DolphinnPy:
+      disabled: true
       docker-tag: ann-benchmarks-dolphinn # Docker tag
       module: ann_benchmarks.algorithms.dolphinnpy # Python class
       constructor: DolphinnPy # Python class name
@@ -8,6 +9,7 @@ float:
         base:
           args: [[10, 50, 100, 200, 1000, 2000]]
     faiss-lsh:
+      disabled: true
       docker-tag: ann-benchmarks-faiss
       module: ann_benchmarks.algorithms.faiss
       constructor: FaissLSH
@@ -37,6 +39,7 @@ float:
         flann:
           args: [[0.2, 0.5, 0.7, 0.8, 0.9, 0.95, 0.97]]
     panns:
+      disabled: true
       docker-tag: ann-benchmarks-panns
       module: ann_benchmarks.algorithms.panns
       constructor: PANNS
@@ -62,6 +65,7 @@ float:
           # 100), Annoy("angular", 200), and Annoy("angular", 400) -- each of
           # which will be used to run 12 different queries.
     nearpy:
+      disabled: true
       docker-tag: ann-benchmarks-nearpy
       module: ann_benchmarks.algorithms.nearpy
       constructor: NearPy

--- a/ann_benchmarks/algorithms/definitions.py
+++ b/ann_benchmarks/algorithms/definitions.py
@@ -12,7 +12,7 @@ from enum import Enum
 from itertools import product
 
 
-Definition = collections.namedtuple('Definition', ['algorithm', 'constructor', 'module', 'docker_tag', 'arguments', 'query_argument_groups'])
+Definition = collections.namedtuple('Definition', ['algorithm', 'constructor', 'module', 'docker_tag', 'arguments', 'query_argument_groups', 'disabled'])
 
 
 def instantiate_algorithm(definition):
@@ -21,10 +21,12 @@ def instantiate_algorithm(definition):
     constructor = getattr(module, definition.constructor)
     return constructor(*definition.arguments)
 
+
 class InstantiationStatus(Enum):
     AVAILABLE = 0
     NO_CONSTRUCTOR = 1
     NO_MODULE = 2
+
 
 def algorithm_status(definition):
     try:
@@ -35,6 +37,7 @@ def algorithm_status(definition):
             return InstantiationStatus.NO_CONSTRUCTOR
     except ImportError:
         return InstantiationStatus.NO_MODULE
+
 
 def get_result_filename(dataset, count, definition, query_arguments):
     d = ['results',
@@ -97,6 +100,7 @@ def get_unique_algorithms(definition_file):
             for algorithm in definitions[point][metric]:
                 algos.add(algorithm)
     return list(sorted(algos))
+
 
 def get_definitions(definition_file, dimension, point_type="float", distance_metric="euclidean", count=10):
     definitions = _get_definitions(definition_file)
@@ -167,7 +171,8 @@ def get_definitions(definition_file, dimension, point_type="float", distance_met
                     module=algo['module'],
                     constructor=algo['constructor'],
                     arguments=aargs,
-                    query_argument_groups=query_args
+                    query_argument_groups=query_args,
+                    disabled=algo.get('disabled', False)
                 ))
 
     return definitions

--- a/ann_benchmarks/main.py
+++ b/ann_benchmarks/main.py
@@ -55,8 +55,7 @@ def main():
     parser.add_argument(
         '--list-algorithms',
         help='print the names of all known algorithms and exit',
-        action='store_true',
-        default=argparse.SUPPRESS)
+        action='store_true')
     parser.add_argument(
         '--force',
         help='''re-run algorithms even if their results already exist''',
@@ -81,12 +80,16 @@ def main():
         type=int,
         help='Max number of algorithms to run (just used for testing)',
         default=-1)
+    parser.add_argument(
+        '--run-disabled',
+        help='run algorithms that are disabled in algos.yml',
+        action='store_true')
 
     args = parser.parse_args()
     if args.timeout == -1:
         args.timeout = None
 
-    if hasattr(args, "list_algorithms"):
+    if args.list_algorithms:
         list_algorithms(args.definitions)
         sys.exit(0)
 
@@ -163,6 +166,11 @@ def main():
             else:
                 return True
         definitions = [d for d in definitions if _test(d)]
+
+    if not args.run_disabled:
+        if len([d for d in definitions if d.disabled]):
+            print('Not running disabled algorithms:', [d for d in definitions if d.disabled])
+        definitions = [d for d in definitions if not d.disabled]
 
     if args.max_n_algorithms >= 0:
         definitions = definitions[:args.max_n_algorithms]

--- a/ann_benchmarks/runner.py
+++ b/ann_benchmarks/runner.py
@@ -171,7 +171,8 @@ def run_from_cmdline():
         module=args.module,
         constructor=args.constructor,
         arguments=algo_args,
-        query_argument_groups=query_args
+        query_argument_groups=query_args,
+        disabled=False
     )
     run(definition, args.dataset, args.count)
 


### PR DESCRIPTION
Keep the unit tests for now, just don't run them by default (unless you pass the `--run-disabled` flag)

