### PR TITLE
Support for Batch mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,8 @@ before_install:
 
 script:
   - python run.py --docker-tag ann-benchmarks-${LIBRARY} --max-n-algorithms 5 --dataset random-xs-20-angular --run-disabled
+  - python run.py --docker-tag ann-benchmarks-${LIBRARY} --max-n-algorithms 5 --dataset random-xs-20-angular --run-disabled --batch
   - python plot.py --dataset random-xs-20-angular --output plot.png
+  - python plot.py --dataset random-xs-20-angular --output plot-batch.png --batch
   - python -m unittest test/test-metrics.py
   - python create_website.py --outputdir . --scatter --latex

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Running
 =======
 
 1. Run `python run.py` (this can take an extremely long time, potentially days)
-2. Run `python plot.py` to plot results.
+2. Run `python plot.py` or `python create_website.py` to plot results.
 
 You can customize the algorithms and datasets if you want to:
 
@@ -116,14 +116,23 @@ Principles
 * Make everything easy to replicate, including installing and preparing the datasets.
 * Try many different values of parameters for each library and ignore the points that are not on the precision-performance frontier.
 * High-dimensional datasets with approximately 100-1000 dimensions. This is challenging but also realistic. Not more than 1000 dimensions because those problems should probably be solved by doing dimensionality reduction separately.
-* No batching of queries, use single queries by default. ANN-Benchmarks saturates CPU cores by using a thread pool.
+* Single queries are used by default. ANN-Benchmarks enforces that only one CPU is saturated during experimentation, i.e., no multi-threading. A batch mode is available that provides all queries to the implementations at once. Add the flag `--batch` to `run.py` and `plot.py` to enable batch mode. 
 * Avoid extremely costly index building (more than several hours).
 * Focus on datasets that fit in RAM. Out of core ANN could be the topic of a later comparison.
-* We currently support CPU-based ANN algorithms. GPU support is planned as future work.
+* We mainly support CPU-based ANN algorithms. GPU support exists for FAISS, but it has to be compiled with GPU support locally and experiments must be run using the flags `--local --batch`. 
 * Do proper train/test set of index data and query points.
 * Note that Hamming distance and set similarity was supported in the past. This might hopefully be added back soon.
+
 
 Authors
 =======
 
 Built by [Erik Bernhardsson](https://erikbern.com) with significant contributions from [Martin Aumüller](http://itu.dk/people/maau/) and [Alexander Faithfull](https://github.com/ale-f).
+
+Related Publication
+==================
+
+The following publication details design principles behind the benchmarking framework: 
+
+- M. Aumüller, E. Bernhardsson, A. Faithfull:
+[ANN-Benchmarks: A Benchmarking Tool for Approximate Nearest Neighbor Algorithms](http://www.itu.dk/people/maau/additional/sisap2017-preprint.pdf). SISAP 2017: 34-49

--- a/algos.yaml
+++ b/algos.yaml
@@ -13,6 +13,7 @@ float:
       docker-tag: ann-benchmarks-faiss
       module: ann_benchmarks.algorithms.faiss
       constructor: FaissLSH
+      base-args: ["@metric"]
       run-groups:
         base:
           # When @args is a list, the result is the Cartesian product of all of

--- a/algos.yaml
+++ b/algos.yaml
@@ -22,15 +22,14 @@ float:
           # This run group will produce eight algorithm instances:
           # FaissLSH(32), FaissLSH(64), and so on up to FaissLSH(4096).
     faiss-ivf:
-      disabled: true
       docker-tag: ann-benchmarks-faiss
       module: ann_benchmarks.algorithms.faiss
       constructor: FaissIVF
       base-args: ["@metric"]
       run-groups:
         base:
-          args: [[5, 10, 20, 50, 100, 200, 400, 800, 1000]]
-          query-args: [[1, 2, 3, 4, 5, 8, 10, 20, 50, 100, 200]]
+          args: [[32,64,128,256,512,1024,2048,4096,8192]]
+          query-args: [[1, 5, 10, 50, 100, 200]]
     faiss-gpu:
       disabled: true
       docker-tag: ann-benchmarks-faiss

--- a/algos.yaml
+++ b/algos.yaml
@@ -31,6 +31,15 @@ float:
         base:
           args: [[5, 10, 20, 50, 100, 200, 400, 800, 1000]]
           query-args: [[1, 2, 3, 4, 5, 8, 10, 20, 50, 100, 200]]
+    faiss-gpu:
+      disabled: true
+      docker-tag: ann-benchmarks-faiss
+      module: ann_benchmarks.algorithms.faiss_gpu
+      constructor: FaissGPU
+      run-groups:
+        base:
+          args: [[400, 1024, 4096, 8192, 16384],
+                 [1, 10, 40, 100, 200]]
     hnswlib:
       docker-tag: ann-benchmarks-hnswlib
       module: ann_benchmarks.algorithms.hnswlib

--- a/ann_benchmarks/algorithms/base.py
+++ b/ann_benchmarks/algorithms/base.py
@@ -18,7 +18,7 @@ class BaseANN(object):
     def batch_query(self, X, n):
         self.res = []
         for q in X:
-            res.append(self.query(q, n))
+            self.res.append(self.query(q, n))
 
     def get_batch_results(self):
         return self.res

--- a/ann_benchmarks/algorithms/base.py
+++ b/ann_benchmarks/algorithms/base.py
@@ -5,12 +5,6 @@ class BaseANN(object):
     def done(self):
         pass
 
-    def batch_query(self, X, n):
-        res = []
-        for q in X:
-            res.append(self.query(q, n))
-        return res
-
     def get_index_size(self, process):
         """Returns the size of the index in kB or -1 if not implemented."""
         return psutil.Process().memory_info().rss / 1024  # return in kB for backwards compatibility
@@ -20,6 +14,14 @@ class BaseANN(object):
 
     def query(self, q, n):
         return [] # array of candidate indices
+
+    def batch_query(self, X, n):
+        self.res = []
+        for q in X:
+            res.append(self.query(q, n))
+
+    def get_batch_results(self):
+        return self.res
 
     def __str__(self):
         return self.name

--- a/ann_benchmarks/algorithms/definitions.py
+++ b/ann_benchmarks/algorithms/definitions.py
@@ -36,7 +36,6 @@ def algorithm_status(definition):
     except ImportError:
         return InstantiationStatus.NO_MODULE
 
-
 def _generate_combinations(args):
     if isinstance(args, list):
         args = [el if isinstance(el, list) else [el] for el in args]

--- a/ann_benchmarks/algorithms/definitions.py
+++ b/ann_benchmarks/algorithms/definitions.py
@@ -12,6 +12,11 @@ from itertools import product
 
 Definition = collections.namedtuple('Definition', ['algorithm', 'constructor', 'module', 'docker_tag', 'arguments', 'query_argument_groups', 'disabled'])
 
+def get_algorithm_name(name, batch):
+    if batch:
+        return name + "-batch"
+    return name
+
 
 def instantiate_algorithm(definition):
     print('Trying to instantiate %s.%s(%s)' % (definition.module, definition.constructor, definition.arguments))

--- a/ann_benchmarks/algorithms/faiss.py
+++ b/ann_benchmarks/algorithms/faiss.py
@@ -7,34 +7,45 @@ import ctypes
 import faiss
 from ann_benchmarks.algorithms.base import BaseANN
 
-class FaissLSH(BaseANN):
-    def __init__(self, n_bits):
+class Faiss(BaseANN):
+    def query(self, v, n):
+        if self._metric == 'angular':
+            v /= numpy.linalg.norm(v)
+        D, I = self.index.search(numpy.expand_dims(v,axis=0).astype(numpy.float32), n)
+        return I[0]
+
+    def batch_query(self, X, n):
+        if self._metric == 'angular':
+            X /= numpy.linalg.norm(X)
+        self.res = self.index.search(X.astype(numpy.float32), n)
+
+    def get_batch_results(self):
+        D, L = self.res
+        res = []
+        for i in range(len(D)):
+            r = []
+            for l, d in zip(L[i], D[i]):
+                if l != -1:
+                    r.append(l)
+            res.append(r)
+        return res
+
+class FaissLSH(Faiss):
+    def __init__(self, metric, n_bits):
         self._n_bits = n_bits
-        self._index = None
+        self.index = None
+        self._metric = metric
         self.name = 'FaissLSH(n_bits={})'.format(self._n_bits)
 
     def fit(self, X):
         if X.dtype != numpy.float32:
             X = X.astype(numpy.float32)
         f = X.shape[1]
-        self._index = faiss.IndexLSH(f, self._n_bits)
-        self._index.train(X)
-        self._index.add(X)
+        self.index = faiss.IndexLSH(f, self._n_bits)
+        self.index.train(X)
+        self.index.add(X)
 
-    def query(self, v, n):
-        return [label for label, _ in self.query_with_distances(v, n)]
-
-    def query_with_distances(self, v, n):
-        v = v.astype(numpy.float32).reshape(1, -1)
-        distances, labels = self._index.search(v, n)
-        r = []
-        for l, d in zip(labels[0], distances[0]):
-            if l != -1:
-                r.append((l, d))
-        return r
-
-
-class FaissIVF(BaseANN):
+class FaissIVF(Faiss):
     def __init__(self, metric, n_list):
         self._n_list = n_list
         self._metric = metric
@@ -55,26 +66,6 @@ class FaissIVF(BaseANN):
     def set_query_arguments(self, n_probe):
         self._n_probe = n_probe
         self.index.nprobe = self._n_probe
-
-    def query(self, v, n):
-        if self._metric == 'angular':
-            v /= numpy.linalg.norm(v)
-        (dist,), (ids,) = self.index.search(v.reshape(1, -1).astype('float32'), n)
-        return ids
-
-    def batch_query(self, X, n):
-        self.res = self.index.search(X.astype(numpy.float32), n)
-
-    def get_batch_results(self):
-        D, L = self.res
-        res = []
-        for i in range(len(D)):
-            r = []
-            for l, d in zip(L[i], D[i]):
-                if l != -1:
-                    r.append(l)
-            res.append(r)
-        return res
 
     def __str__(self):
         return 'FaissIVF(n_list=%d, n_probe=%d)' % (self._n_list, self._n_probe)

--- a/ann_benchmarks/algorithms/faiss_gpu.py
+++ b/ann_benchmarks/algorithms/faiss_gpu.py
@@ -39,9 +39,12 @@ class FaissGPU(BaseANN):
         return r
 
     def batch_query(self, X, n):
-        D, L = self._index.search(X, n)
+        self.res = self._index.search(X.astype(numpy.float32),n)
+
+    def get_batch_results(self):
+        D, L = self.res
         res = []
-        for i in range(len(X)):
+        for i in range(len(D)):
             r = []
             for l, d in zip(L[i], D[i]):
                 if l != -1:

--- a/ann_benchmarks/algorithms/faiss_gpu.py
+++ b/ann_benchmarks/algorithms/faiss_gpu.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 import sys
-sys.path.append("install/lib-faiss")
+# Assumes local installation of FAISS
+sys.path.append("faiss")
 import numpy
 import ctypes
 import faiss
@@ -18,10 +19,12 @@ class FaissGPU(BaseANN):
 
     def fit(self, X):
         X = X.astype(numpy.float32)
-        self._index = faiss.index_factory(len(X[0]), "IVF%d,PQ64" % self._n_bits)
-        co = faiss.GpuClonerOptions()
-        co.useFloat16 = True
-        self._index = faiss.index_cpu_to_gpu(self._res, 0, self._index, co)
+        self._index = faiss.GpuIndexIVFFlat(self._res, len(X[0]), self._n_bits,
+                                               faiss.METRIC_L2)
+#        self._index = faiss.index_factory(len(X[0]), "IVF%d,Flat" % self._n_bits)
+#        co = faiss.GpuClonerOptions()
+#        co.useFloat16 = True
+#        self._index = faiss.index_cpu_to_gpu(self._res, 0, self._index, co)
         self._index.train(X)
         self._index.add(X)
         self._index.setNumProbes(self._n_probes)

--- a/ann_benchmarks/algorithms/nmslib.py
+++ b/ann_benchmarks/algorithms/nmslib.py
@@ -57,4 +57,9 @@ class NmslibReuseIndex(BaseANN):
         ids, distances = self._index.knnQuery(v, n)
         return ids
 
+    def batch_query(self, X, n):
+        self.res = self._index.knnQueryBatch(X, n)
+
+    def get_batch_results(self):
+        return [x for x, _ in self.res]
 

--- a/ann_benchmarks/main.py
+++ b/ann_benchmarks/main.py
@@ -117,8 +117,8 @@ def main():
         not_yet_run = []
         for query_arguments in query_argument_groups:
             fn = get_result_filename(args.dataset,
-                    args.count, definition, query_arguments)
-            if not os.path.exists(fn):
+                    args.count, definition, query_arguments, args.batch)
+            if args.force or not os.path.exists(fn):
                 not_yet_run.append(query_arguments)
         if not_yet_run:
             if definition.query_argument_groups:

--- a/ann_benchmarks/main.py
+++ b/ann_benchmarks/main.py
@@ -189,10 +189,10 @@ def main():
         print(definition, '...')
 
         try:
-            f = run_docker
             if args.local:
-                f = run
-            f(definition, args.dataset, args.count, args.runs, args.timeout, args.batch)
+                run(definition, args.dataset, args.count, args.runs, args.batch)
+            else:
+                run_docker(definition, args.dataset, args.count, args.runs, args.timeout, args.batch)
         except KeyboardInterrupt:
             break
         except:

--- a/ann_benchmarks/main.py
+++ b/ann_benchmarks/main.py
@@ -71,7 +71,7 @@ def main():
         '--timeout',
         type=int,
         help='Timeout (in seconds) for each individual algorithm run, or -1 if no timeout should be set',
-        default=-1)
+        default=5*3600)
     parser.add_argument(
         '--local',
         action='store_true',
@@ -189,10 +189,10 @@ def main():
         print(definition, '...')
 
         try:
+            f = run_docker
             if args.local:
-                run(definition, args.dataset, args.count, args.runs, use_batch_query=args.batch)
-            else:
-                run_docker(definition, args.dataset, args.count, args.runs, use_batch_query=args.batch)
+                f = run
+            f(definition, args.dataset, args.count, args.runs, args.timeout, args.batch)
         except KeyboardInterrupt:
             break
         except:

--- a/ann_benchmarks/main.py
+++ b/ann_benchmarks/main.py
@@ -77,6 +77,10 @@ def main():
         action='store_true',
         help='If set, then will run everything locally (inside the same process) rather than using Docker')
     parser.add_argument(
+        '--batch',
+        action='store_true',
+        help='If set, algorithms get all queries at once')
+    parser.add_argument(
         '--max-n-algorithms',
         type=int,
         help='Max number of algorithms to run (just used for testing)',

--- a/ann_benchmarks/main.py
+++ b/ann_benchmarks/main.py
@@ -190,9 +190,9 @@ def main():
 
         try:
             if args.local:
-                run(definition, args.dataset, args.count, args.runs)
+                run(definition, args.dataset, args.count, args.runs, use_batch_query=args.batch)
             else:
-                run_docker(definition, args.dataset, args.count, args.runs)
+                run_docker(definition, args.dataset, args.count, args.runs, use_batch_query=args.batch)
         except KeyboardInterrupt:
             break
         except:

--- a/ann_benchmarks/results.py
+++ b/ann_benchmarks/results.py
@@ -25,7 +25,7 @@ def get_result_filename(dataset=None, count=None, definition=None, query_argumen
             d.append(re.sub(r'\W+', '_', json.dumps(definition.arguments + query_arguments, sort_keys=True)).strip('_'))
     return os.path.join(*d)
 
-def store_results(dataset, count, definition, query_arguments, attrs, results, batch=False):
+def store_results(dataset, count, definition, query_arguments, attrs, results, batch):
     fn = get_result_filename(dataset, count, definition, query_arguments, batch)
     head, tail = os.path.split(fn)
     if not os.path.isdir(head):

--- a/ann_benchmarks/results.py
+++ b/ann_benchmarks/results.py
@@ -5,20 +5,28 @@ import json
 import os
 import re
 
-def get_result_filename(dataset=None, count=None, definition=None, query_arguments=None):
+def get_algorithm_name(name, batch_mode):
+    if batch_mode:
+        return name + "-batch"
+    return name
+
+def is_batch(name):
+    return "-batch" in name
+
+def get_result_filename(dataset=None, count=None, definition=None, query_arguments=None, batch_mode=False):
     d = ['results']
     if dataset:
         d.append(dataset)
     if count:
         d.append(str(count))
     if definition:
-        d.append(definition.algorithm)
+        d.append(get_algorithm_name(definition.algorithm, batch_mode))
         if query_arguments:
             d.append(re.sub(r'\W+', '_', json.dumps(definition.arguments + query_arguments, sort_keys=True)).strip('_'))
     return os.path.join(*d)
 
-def store_results(dataset, count, definition, query_arguments, attrs, results):
-    fn = get_result_filename(dataset, count, definition, query_arguments)
+def store_results(dataset, count, definition, query_arguments, attrs, results, batch_mode=False):
+    fn = get_result_filename(dataset, count, definition, query_arguments, batch_mode)
     head, tail = os.path.split(fn)
     if not os.path.isdir(head):
         os.makedirs(head)
@@ -35,10 +43,12 @@ def store_results(dataset, count, definition, query_arguments, attrs, results):
     f.close()
 
 
-def load_all_results(dataset=None, count=None):
+def load_all_results(dataset=None, count=None, batch_mode=False):
     for root, _, files in os.walk(get_result_filename(dataset, count)):
         for fn in files:
             try:
+                if batch_mode != is_batch(root):
+                    continue
                 f = h5py.File(os.path.join(root, fn))
                 properties = dict(f.attrs)
                 # TODO Fix this properly. Sometimes the hdf5 file returns bytes

--- a/ann_benchmarks/results.py
+++ b/ann_benchmarks/results.py
@@ -43,11 +43,11 @@ def store_results(dataset, count, definition, query_arguments, attrs, results, b
     f.close()
 
 
-def load_all_results(dataset=None, count=None, batch_mode=False):
+def load_all_results(dataset=None, count=None, split_batched=False,  batch_mode=False):
     for root, _, files in os.walk(get_result_filename(dataset, count)):
         for fn in files:
             try:
-                if batch_mode != is_batch(root):
+                if split_batched and batch_mode != is_batch(root):
                     continue
                 f = h5py.File(os.path.join(root, fn))
                 properties = dict(f.attrs)

--- a/ann_benchmarks/results.py
+++ b/ann_benchmarks/results.py
@@ -21,8 +21,7 @@ def get_result_filename(dataset=None, count=None, definition=None, query_argumen
         d.append(str(count))
     if definition:
         d.append(get_algorithm_name(definition.algorithm, batch_mode))
-        if query_arguments:
-            d.append(re.sub(r'\W+', '_', json.dumps(definition.arguments + query_arguments, sort_keys=True)).strip('_'))
+        d.append(re.sub(r'\W+', '_', json.dumps(definition.arguments + query_arguments, sort_keys=True)).strip('_'))
     return os.path.join(*d)
 
 def store_results(dataset, count, definition, query_arguments, attrs, results, batch):

--- a/ann_benchmarks/results.py
+++ b/ann_benchmarks/results.py
@@ -25,8 +25,8 @@ def get_result_filename(dataset=None, count=None, definition=None, query_argumen
             d.append(re.sub(r'\W+', '_', json.dumps(definition.arguments + query_arguments, sort_keys=True)).strip('_'))
     return os.path.join(*d)
 
-def store_results(dataset, count, definition, query_arguments, attrs, results, batch_mode=False):
-    fn = get_result_filename(dataset, count, definition, query_arguments, batch_mode)
+def store_results(dataset, count, definition, query_arguments, attrs, results, batch=False):
+    fn = get_result_filename(dataset, count, definition, query_arguments, batch)
     head, tail = os.path.split(fn)
     if not os.path.isdir(head):
         os.makedirs(head)

--- a/ann_benchmarks/runner.py
+++ b/ann_benchmarks/runner.py
@@ -24,7 +24,7 @@ from ann_benchmarks.distance import metrics
 from ann_benchmarks.results import store_results
 
 
-def run_individual_query(algo, X_train, X_test, distance, count, run_count, use_batch_query=False):
+def run_individual_query(algo, X_train, X_test, distance, count, run_count, use_batch_query):
     best_search_time = float('inf')
     for i in range(run_count):
         print('Run %d/%d...' % (i+1, run_count))
@@ -175,7 +175,7 @@ def run_from_cmdline():
     run(definition, args.dataset, args.count, args.runs, args.batch)
 
 
-def run_docker(definition, dataset, count, runs, timeout=5*3600, mem_limit=None, use_batch_query=False):
+def run_docker(definition, dataset, count, runs, timeout, use_batch_query, mem_limit=None):
     import colors  # Think it doesn't work in Python 2
 
     cmd = ['--dataset', dataset,

--- a/ann_benchmarks/runner.py
+++ b/ann_benchmarks/runner.py
@@ -5,7 +5,7 @@ import argparse
 import datetime
 import docker
 import json
-import multiprocessing.pool
+import multiprocessing
 import numpy
 import os
 import psutil
@@ -24,7 +24,7 @@ from ann_benchmarks.distance import metrics
 from ann_benchmarks.results import store_results
 
 
-def run_individual_query(algo, X_train, X_test, distance, count, run_count, use_batch_query):
+def run_individual_query(algo, X_train, X_test, distance, count, run_count, use_batch_query=False):
     best_search_time = float('inf')
     for i in range(run_count):
         print('Run %d/%d...' % (i+1, run_count))
@@ -45,8 +45,9 @@ def run_individual_query(algo, X_train, X_test, distance, count, run_count, use_
 
         def batch_query(X):
             start = time.time()
-            result = algo.batch_query(X, count)
+            algo.batch_query(X, count)
             total = (time.time() - start)
+            results = algo.get_batch_results()
             candidates = [[(int(idx), float(metrics[distance]['distance'](v, X_train[idx])))
                            for idx in single_results]
                           for v, single_results in zip(X, results)]
@@ -117,9 +118,11 @@ function""" % (definition.module, definition.constructor, definition.arguments)
             descriptor["build_time"] = build_time
             descriptor["index_size"] = index_size
             descriptor["algo"] = definition.algorithm
+            if use_batch_query:
+                descriptor["algo"] += "-batch"
             descriptor["dataset"] = dataset
-            store_results(dataset,
-                    count, definition, query_arguments, descriptor, results)
+            store_results(dataset, count, definition,
+                    query_arguments, descriptor, results, use_batch_query)
     finally:
         algo.done()
 
@@ -148,6 +151,9 @@ def run_from_cmdline():
         required=True,
         type=int)
     parser.add_argument(
+        '--batch',
+        action='store_true')
+    parser.add_argument(
         'build')
     parser.add_argument(
         'queries',
@@ -166,10 +172,10 @@ def run_from_cmdline():
         query_argument_groups=query_args,
         disabled=False
     )
-    run(definition, args.dataset, args.count, args.runs)
+    run(definition, args.dataset, args.count, args.runs, args.batch)
 
 
-def run_docker(definition, dataset, count, runs, timeout=5*3600, mem_limit=None):
+def run_docker(definition, dataset, count, runs, timeout=5*3600, mem_limit=None, use_batch_query=False):
     import colors  # Think it doesn't work in Python 2
 
     cmd = ['--dataset', dataset,
@@ -178,6 +184,8 @@ def run_docker(definition, dataset, count, runs, timeout=5*3600, mem_limit=None)
            '--constructor', definition.constructor,
            '--runs', str(runs),
            '--count', str(count)]
+    if use_batch_query:
+        cmd += ['--batch']
     cmd.append(json.dumps(definition.arguments))
     cmd += [json.dumps(qag) for qag in definition.query_argument_groups]
     print('Running command', cmd)
@@ -185,6 +193,12 @@ def run_docker(definition, dataset, count, runs, timeout=5*3600, mem_limit=None)
     if mem_limit is None:
         mem_limit = psutil.virtual_memory().available
     print('Memory limit:', mem_limit)
+    cpu_limit = "0-%d" % (multiprocessing.cpu_count() - 1)
+    if not use_batch_query:
+        # Limit to first cpu if not in batch mode
+        cpu_limit = "0"
+    print('Running on CPUs:', cpu_limit)
+
     container = client.containers.run(
         definition.docker_tag,
         cmd,
@@ -193,8 +207,8 @@ def run_docker(definition, dataset, count, runs, timeout=5*3600, mem_limit=None)
             os.path.abspath('data'): {'bind': '/home/app/data', 'mode': 'ro'},
             os.path.abspath('results'): {'bind': '/home/app/results', 'mode': 'rw'},
         },
+        cpuset_cpus=cpu_limit,
         mem_limit=mem_limit,
-        cpuset_cpus='0', # limit to the 1st CPU
         detach=True)
 
     def stream_logs():

--- a/ann_benchmarks/runner.py
+++ b/ann_benchmarks/runner.py
@@ -19,7 +19,7 @@ def print(*args, **kwargs):
     sys.stdout.flush()
 
 from ann_benchmarks.datasets import get_dataset, DATASETS
-from ann_benchmarks.algorithms.definitions import Definition, instantiate_algorithm
+from ann_benchmarks.algorithms.definitions import Definition, instantiate_algorithm, get_algorithm_name
 from ann_benchmarks.distance import metrics
 from ann_benchmarks.results import store_results
 
@@ -78,7 +78,7 @@ def run_individual_query(algo, X_train, X_test, distance, count, run_count, batc
     return (attrs, results)
 
 
-def run(definition, dataset, count, run_count=3, batch=False):
+def run(definition, dataset, count, run_count, batch):
     algo = instantiate_algorithm(definition)
     assert not definition.query_argument_groups \
             or hasattr(algo, "set_query_arguments"), """\
@@ -117,9 +117,7 @@ function""" % (definition.module, definition.constructor, definition.arguments)
                     distance, count, run_count, batch)
             descriptor["build_time"] = build_time
             descriptor["index_size"] = index_size
-            descriptor["algo"] = definition.algorithm
-            if batch:
-                descriptor["algo"] += "-batch"
+            descriptor["algo"] = get_algorithm_name(definition.algorithm, batch)
             descriptor["dataset"] = dataset
             store_results(dataset, count, definition,
                     query_arguments, descriptor, results, batch)

--- a/create_website.py
+++ b/create_website.py
@@ -202,7 +202,9 @@ def load_all_results():
 j2_env = Environment(loader=FileSystemLoader("./templates/"), trim_blocks = True)
 j2_env.globals.update(zip=zip, len=len)
 runs_by_ds, runs_by_algo = load_all_results()
-linestyles = {**create_linestyles([get_dataset_label(x) for x in runs_by_ds.keys()]),  **create_linestyles(runs_by_algo.keys())}
+dataset_names = [get_dataset_label(x) for x in list(runs_by_ds['batch'].keys()) + list(runs_by_ds['non-batch'].keys())]
+algorithm_names = list(runs_by_algo['batch'].keys()) + list(runs_by_algo['non-batch'].keys())
+linestyles = {**create_linestyles(dataset_names), **create_linestyles(algorithm_names)}
 
 build_detail_site(runs_by_ds['non-batch'], lambda label: get_dataset_label(label), j2_env, linestyles, False)
 build_detail_site(runs_by_ds['batch'], lambda label: get_dataset_label(label), j2_env, linestyles, True)

--- a/create_website.py
+++ b/create_website.py
@@ -7,6 +7,7 @@ import hashlib
 from jinja2 import Environment, FileSystemLoader
 
 from ann_benchmarks import results
+from ann_benchmarks.algorithms.definitions import get_algorithm_name
 from ann_benchmarks.datasets import get_dataset
 from ann_benchmarks.plotting.plot_variants import all_plot_variants as plot_variants
 from ann_benchmarks.plotting.metrics import all_metrics as metrics
@@ -145,9 +146,9 @@ def build_detail_site(data, label_func, j2_env, linestyles, batch=False):
         for k in runs.keys():
             data_for_plot[k] = prepare_data(runs[k], 'k-nn', 'qps')
         plot.create_plot(data_for_plot, False,
-                False, True, 'k-nn', 'qps',  args.outputdir + name + "_batch=" + str(batch) + ".png",
+                False, True, 'k-nn', 'qps',  args.outputdir + get_algorithm_name(name, batch) + ".png",
                 linestyles, batch)
-        with open(args.outputdir + name + "_batch=" + str(batch) + ".html", "w") as text_file:
+        with open(args.outputdir + get_algorithm_name(name, batch) + ".html", "w") as text_file:
             text_file.write(j2_env.get_template("detail_page.html").
                 render(title = label, plot_data = data, args = args, batch=batch))
 
@@ -173,7 +174,7 @@ def build_index_site(datasets, algorithms, j2_env, file_name):
     with open(args.outputdir + "index.html", "w") as text_file:
         text_file.write(j2_env.get_template("summary.html").
                 render(title = "ANN-Benchmarks", dataset_with_distances = dataset_data,
-                    algorithms = algorithms))
+                    algorithms = algorithms, label_func=get_algorithm_name))
 
 def load_all_results():
     """Read all result files and compute all metrics"""

--- a/plot.py
+++ b/plot.py
@@ -11,7 +11,7 @@ from ann_benchmarks.plotting.utils  import get_plot_label, compute_metrics, crea
 from ann_benchmarks.results import store_results, load_all_results, get_unique_algorithms
 
 
-def create_plot(all_data, raw, x_log, y_log, xn, yn, fn_out, linestyles):
+def create_plot(all_data, raw, x_log, y_log, xn, yn, fn_out, linestyles, batch):
     xm, ym = (metrics[xn], metrics[yn])
     # Now generate each plot
     handles = []
@@ -24,7 +24,10 @@ def create_plot(all_data, raw, x_log, y_log, xn, yn, fn_out, linestyles):
         handles.append(handle)
         if raw:
             handle2, = plt.plot(axs, ays, '-', label=algo, color=faded, ms=5, mew=2, lw=2, linestyle=linestyle, marker=marker)
-        labels.append(algo)
+        label = algo
+        if batch:
+            label += "-batch"
+        labels.append(label)
 
     if x_log:
         plt.gca().set_xscale('log')
@@ -86,6 +89,10 @@ if __name__ == "__main__":
         '--raw',
         help='Show raw results (not just Pareto frontier) in faded colours',
         action='store_true')
+    parser.add_argument(
+        '--batch',
+        help='Plot runs in batch mode',
+        action='store_true')
     args = parser.parse_args()
 
     if not args.output:
@@ -95,11 +102,11 @@ if __name__ == "__main__":
     dataset = get_dataset(args.dataset)
     count = int(args.count)
     unique_algorithms = get_unique_algorithms()
-    results = load_all_results(args.dataset, count)
+    results = load_all_results(args.dataset, count, args.batch)
     linestyles = create_linestyles(sorted(unique_algorithms))
     runs = compute_metrics(list(dataset["distances"]), results, args.x_axis, args.y_axis)
     if not runs:
         raise Exception('Nothing to plot')
 
     create_plot(runs, args.raw, args.x_log,
-            args.y_log, args.x_axis, args.y_axis, args.output, linestyles)
+            args.y_log, args.x_axis, args.y_axis, args.output, linestyles, args.batch)

--- a/plot.py
+++ b/plot.py
@@ -99,7 +99,7 @@ if __name__ == "__main__":
     dataset = get_dataset(args.dataset)
     count = int(args.count)
     unique_algorithms = get_unique_algorithms()
-    results = load_all_results(args.dataset, count, args.batch)
+    results = load_all_results(args.dataset, count, True, args.batch)
     linestyles = create_linestyles(sorted(unique_algorithms))
     runs = compute_metrics(list(dataset["distances"]), results, args.x_axis, args.y_axis)
     if not runs:

--- a/plot.py
+++ b/plot.py
@@ -8,7 +8,7 @@ from ann_benchmarks.datasets import get_dataset
 from ann_benchmarks.algorithms.definitions import get_definitions
 from ann_benchmarks.plotting.metrics import all_metrics as metrics
 from ann_benchmarks.plotting.utils  import get_plot_label, compute_metrics, create_linestyles, create_pointset
-from ann_benchmarks.results import store_results, load_all_results, get_unique_algorithms
+from ann_benchmarks.results import store_results, load_all_results, get_unique_algorithms, get_algorithm_name
 
 
 def create_plot(all_data, raw, x_log, y_log, xn, yn, fn_out, linestyles, batch):
@@ -24,10 +24,7 @@ def create_plot(all_data, raw, x_log, y_log, xn, yn, fn_out, linestyles, batch):
         handles.append(handle)
         if raw:
             handle2, = plt.plot(axs, ays, '-', label=algo, color=faded, ms=5, mew=2, lw=2, linestyle=linestyle, marker=marker)
-        label = algo
-        if batch:
-            label += "-batch"
-        labels.append(label)
+        labels.append(get_algorithm_name(algo, batch))
 
     if x_log:
         plt.gca().set_xscale('log')
@@ -96,7 +93,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     if not args.output:
-        args.output = 'results/%s.png' % args.dataset
+        args.output = 'results/%s.png' % get_algorithm_name(args.dataset, args.batch)
         print('writing output to %s' % args.output)
 
     dataset = get_dataset(args.dataset)

--- a/templates/detail_page.html
+++ b/templates/detail_page.html
@@ -3,9 +3,17 @@
         <div class="container">
         {% for item in plot_data.keys() %}
             {% if item=="normal" %}
-            <h2>Plots for {{title}}</h2>
+                {% if batch %}
+                    <h2>Plots for {{title}} in batch mode</h2>
+                {% else %}
+                    <h2>Plots for {{title}}</h2>
+                {% endif %}
             {% elif item=="scatter" and args.scatter %}
-            <h2>Scatterplots for {{title}}</h2>
+                {% if batch %}
+                    <h2>Scatterplots for {{title}} in batch mode</h2>
+                {% else %}
+                    <h2>Scatterplots for {{title}}</h2>
+                {% endif %}
             {% endif %}
             {% for plot in plot_data[item] %}
             {{ plot }}

--- a/templates/summary.html
+++ b/templates/summary.html
@@ -23,21 +23,13 @@
                     {% for distance_data in dataset_with_distances[type] %}
                         <h3>Distance: {{ distance_data.name }} </h3>
                         {% for entry in distance_data.entries %}
-                            {% if type == 'batch' %}
-                            <a href="./{{entry.name}}_batch=True.html">
-                            {% else %}
-                            <a href="./{{entry.name}}_batch=False.html">
-                            {% endif %}
+                            <a href="./{{label_func(entry.name, type == 'batch')}}.html">
                             <div class="row" id="{{entry.name}}">
                                 <div class = "col-md-4 bg-success">
                                     <h4>{{entry.desc}}</h4>
                             </div>
                             <div class = "col-md-8">
-                                {% if type == 'batch' %}
-                                <img class = "img-responsive" src="{{entry.name}}_batch=True.png" />
-                                {% else %}
-                                <img class = "img-responsive" src="{{entry.name}}_batch=False.png" />
-                                {% endif %}
+                                <img class = "img-responsive" src="{{label_func(entry.name, type == 'batch')}}.png" />
                             </div>
                         </div>
                         </a>
@@ -51,21 +43,13 @@
                         {% endfor %}
                     </ul>
                     {% for algo in algorithms[type].keys()%}
-                        {% if type == 'batch' %}
-                            <a href="./{{algo}}_batch=True.html">
-                        {% else %}
-                            <a href="./{{algo}}_batch=False.html">
-                        {% endif %}
+                    <a href="./{{label_func(algo, type == 'batch')}}.html">
                         <div class="row" id="{{algo}}">
                             <div class = "col-md-4 bg-success">
                                 <h4>{{algo}}</h4>
                         </div>
                         <div class = "col-md-8">
-                            {% if type == 'batch' %}
-                                <img class = "img-responsive" src="{{algo}}_batch=True.png" />
-                            {% else %}
-                                <img class = "img-responsive" src="{{algo}}_batch=False.png" />
-                            {% endif %}
+                            <img class = "img-responsive" src="{{label_func(algo, type == 'batch')}}.png" />
                         </div>
                     </div>
                     </a>

--- a/templates/summary.html
+++ b/templates/summary.html
@@ -11,40 +11,66 @@
             by <em>(k = ...)</em>, the number of nearest neighbors an algorithm was supposed to return. The plot shown depicts <em>Recall</em> (the fraction
             of true nearest neighbors found, on average over all queries) against <em>Queries per second</em>.  Clicking on a plot reveils detailled interactive plots, including
             approximate recall, index size, and build time.</p>
-            <h2 id ="datasets">Results by Dataset</h2>
-            {% for distance_data in dataset_with_distances %}
-                <h3>Distance: {{ distance_data.name }} </h3>
-                {% for entry in distance_data.entries %}
-                <a href="./{{entry.name}}.html">
-                    <div class="row" id="{{entry.name}}">
-                        <div class = "col-md-4 bg-success">
-                            <h4>{{entry.desc}}</h4>
+            {% for type in ['non-batch', 'batch'] %}
+                {% if len(dataset_with_distances[type]) > 0 %}
+                    {% if type == 'batch' %}
+                        <h2>Benchmarks for Batched Queries</h2>
+                    {% else %}
+                        <h2>Benchmarks for Single Queries</h2>
+                    {% endif %}
+
+                    <h2 id ="datasets">Results by Dataset</h2>
+                    {% for distance_data in dataset_with_distances[type] %}
+                        <h3>Distance: {{ distance_data.name }} </h3>
+                        {% for entry in distance_data.entries %}
+                            {% if type == 'batch' %}
+                            <a href="./{{entry.name}}_batch=True.html">
+                            {% else %}
+                            <a href="./{{entry.name}}_batch=False.html">
+                            {% endif %}
+                            <div class="row" id="{{entry.name}}">
+                                <div class = "col-md-4 bg-success">
+                                    <h4>{{entry.desc}}</h4>
+                            </div>
+                            <div class = "col-md-8">
+                                {% if type == 'batch' %}
+                                <img class = "img-responsive" src="{{entry.name}}_batch=True.png" />
+                                {% else %}
+                                <img class = "img-responsive" src="{{entry.name}}_batch=False.png" />
+                                {% endif %}
+                            </div>
+                        </div>
+                        </a>
+                        <hr />
+                        {% endfor %}
+                    {% endfor %}
+                    <h2 id="algorithms">Results by Algorithm</h2>
+                    <ul class="list-inline"><b>Algorithms:</b>
+                        {% for algo in algorithms[type].keys() %}
+                            <li><a href="#{{algo}}">{{algo}}</a></li>
+                        {% endfor %}
+                    </ul>
+                    {% for algo in algorithms[type].keys()%}
+                        {% if type == 'batch' %}
+                            <a href="./{{algo}}_batch=True.html">
+                        {% else %}
+                            <a href="./{{algo}}_batch=False.html">
+                        {% endif %}
+                        <div class="row" id="{{algo}}">
+                            <div class = "col-md-4 bg-success">
+                                <h4>{{algo}}</h4>
+                        </div>
+                        <div class = "col-md-8">
+                            {% if type == 'batch' %}
+                                <img class = "img-responsive" src="{{algo}}_batch=True.png" />
+                            {% else %}
+                                <img class = "img-responsive" src="{{algo}}_batch=False.png" />
+                            {% endif %}
+                        </div>
                     </div>
-                    <div class = "col-md-8">
-                        <img class = "img-responsive" src="{{entry.name}}.png" />
-                    </div>
-                </div>
-                </a>
-                <hr />
-                {% endfor %}
-            {% endfor %}
-            <h2 id="algorithms">Results by Algorithm</h2>
-            <ul class="list-inline"><b>Algorithms:</b>
-                {% for algo in algorithms %}
-                <li><a href="#{{algo}}">{{algo}}</a></li>
-                {% endfor %}
-            </ul>
-            {% for algo in algorithms%}
-            <a href="./{{algo}}.html">
-                <div class="row" id="{{algo}}">
-                    <div class = "col-md-4 bg-success">
-                        <h4>{{algo}}</h4>
-                </div>
-                <div class = "col-md-8">
-                    <img class = "img-responsive" src="{{algo}}.png" />
-                </div>
-            </div>
-            </a>
-            <hr />
+                    </a>
+                    <hr />
+                    {% endfor %}
+                {% endif %}
             {% endfor %}
 {% endblock %}


### PR DESCRIPTION
This PR improves the rudimentary support for batch mode that is already present in ann-benchmarks. Batch mode is enabled by providing `--batch` to `run.py`. Runs in non-batch/batch mode are treated completely independently by the the plotting scripts. That means `--batch` has to be provided to `plot.py` to plot results for batched runs; the website generated by`create_website.py` has different sections for batched/non-batched queries, where all batched runs have to suffix "-batch".

The approach is pretty straight-forward: There is a method `batch_query(X)` that gets the whole query set at once. The default implementation is to query each individual point with the standard query procedure, but all of faiss' and nmslib's implementations support a dedicated batch method that is used in this case. We can also run faiss' GPU implementation in this way.  

I fixed a few bugs on the way, see the individual commits. 

## Results for `random-xs-20-euclidean`:

Admittedly, not the most interesting dataset :-)

### Single queries

![random-xs-20-euclidean](https://user-images.githubusercontent.com/6311646/41910820-195637aa-794b-11e8-8c34-9ce7d1c97422.png)

### Batched queries
![random-xs-20-euclidean-batch](https://user-images.githubusercontent.com/6311646/41910830-1e08cf42-794b-11e8-9355-42eea31c4d81.png)

Of course, comparing a GPU implementation against CPU implementations is a bit odd here, but it clearly shows where the current bar for fast ANN algorithms is. 

 

