### PR TITLE
Bitvectors and Hamming distance

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Principles
 * Focus on datasets that fit in RAM. Out of core ANN could be the topic of a later comparison.
 * We mainly support CPU-based ANN algorithms. GPU support exists for FAISS, but it has to be compiled with GPU support locally and experiments must be run using the flags `--local --batch`. 
 * Do proper train/test set of index data and query points.
-* Note that Hamming distance and set similarity was supported in the past. This might hopefully be added back soon.
+* Note that set similarity was supported in the past. This might hopefully be added back soon.
 
 
 Authors

--- a/algos.yaml
+++ b/algos.yaml
@@ -457,7 +457,7 @@ bit:
       docker-tag: ann-benchmarks-kgraph
       module: ann_benchmarks.algorithms.kgraph
       constructor: KGraph
-      base-args: ["@metric"]
+      base-args: ["euclidean"]
       run-groups:
         kgraph:
           args: [[1, 2, 3, 4, 5, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100],
@@ -466,7 +466,7 @@ bit:
       docker-tag: ann-benchmarks-nmslib
       module: ann_benchmarks.algorithms.nmslib
       constructor: NmslibReuseIndex
-      base-args: ["@metric", "hnsw"]
+      base-args: ["euclidean", "hnsw"]
       run-groups:
         M-48:
           arg-groups:
@@ -490,7 +490,7 @@ bit:
       docker-tag: ann-benchmarks-pynndescent
       module: ann_benchmarks.algorithms.pynndescent
       constructor: PyNNDescent
-      base-args: ["@metric"]
+      base-args: ["euclidean"]
       run-groups:
         pynndescent:
           args: [[20, 40, 80, 160, 250], [4], [40]]
@@ -512,7 +512,7 @@ bit:
       docker-tag: ann-benchmarks-faiss
       module: ann_benchmarks.algorithms.faiss
       constructor: FaissIVF
-      base-args: ["@metric"]
+      base-args: ["euclidean"]
       run-groups:
         base:
           args: [[32,64,128,256,512,1024,2048,4096,8192]]

--- a/algos.yaml
+++ b/algos.yaml
@@ -485,7 +485,7 @@ bit:
         M-12:
           arg-groups:
             - {"M": 12, "post": 0, "efConstruction": 800}
-        query-args: [[1, 2, 5, 10, 15, 20, 30, 40, 50, 70, 80]]
+          query-args: [[1, 2, 5, 10, 15, 20, 30, 40, 50, 70, 80]]
     pynndescent:
       docker-tag: ann-benchmarks-pynndescent
       module: ann_benchmarks.algorithms.pynndescent

--- a/algos.yaml
+++ b/algos.yaml
@@ -495,6 +495,28 @@ bit:
         pynndescent:
           args: [[20, 40, 80, 160, 250], [4], [40]]
           query-args: [[1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0]]
+    annoy:
+      docker-tag: ann-benchmarks-annoy
+      module: ann_benchmarks.algorithms.annoy
+      constructor: Annoy
+      base-args: ["@metric"]
+      run-groups:
+        annoy:
+          args: [[100, 200, 400]]
+          query-args: [[100, 200, 400, 1000, 2000, 4000, 10000, 20000, 40000,
+                      100000, 200000, 400000]]
+          # This run group produces 3 algorithm instances -- Annoy("angular",
+          # 100), Annoy("angular", 200), and Annoy("angular", 400) -- each of
+          # which will be used to run 12 different queries.
+    faiss-ivf:
+      docker-tag: ann-benchmarks-faiss
+      module: ann_benchmarks.algorithms.faiss
+      constructor: FaissIVF
+      base-args: ["@metric"]
+      run-groups:
+        base:
+          args: [[32,64,128,256,512,1024,2048,4096,8192]]
+          query-args: [[1, 5, 10, 50, 100, 200]]
 int:
   jaccard:
     bf:

--- a/ann_benchmarks/algorithms/bruteforce.py
+++ b/ann_benchmarks/algorithms/bruteforce.py
@@ -43,13 +43,16 @@ class BruteForceBLAS(BaseANN):
             lens = (X ** 2).sum(-1)  # precompute (squared) length of each vector
             X /= numpy.sqrt(lens)[..., numpy.newaxis]  # normalize index vectors to unit length
             self.index = numpy.ascontiguousarray(X, dtype=self._precision)
+        elif self._metric == 'hamming':
+            # Regarding bitvectors as vectors in l_2 is faster for blas
+            X = X.astype(numpy.float32)
+            lens = (X ** 2).sum(-1)  # precompute (squared) length of each vector
+            self.index = numpy.ascontiguousarray(X, dtype=numpy.float32)
+            self.lengths = numpy.ascontiguousarray(lens, dtype=numpy.float32)
         elif self._metric == 'euclidean':
             lens = (X ** 2).sum(-1)  # precompute (squared) length of each vector
             self.index = numpy.ascontiguousarray(X, dtype=self._precision)
             self.lengths = numpy.ascontiguousarray(lens, dtype=self._precision)
-        elif self._metric == 'hamming':
-            self.index = numpy.ascontiguousarray(
-                list(map(numpy.packbits, X)), dtype=numpy.uint8)
         elif self._metric == 'jaccard':
             self.index = X
         else:
@@ -58,14 +61,8 @@ class BruteForceBLAS(BaseANN):
     def query(self, v, n):
         return [index for index, _ in self.query_with_distances(v, n)]
 
-    popcount = []
-    for i in range(256):
-      popcount.append(bin(i).count("1"))
-
     def query_with_distances(self, v, n):
         """Find indices of `n` most similar vectors from the index to query vector `v`."""
-        if self._metric == 'hamming':
-            v = numpy.packbits(v)
 
         if self._metric != 'jaccard':
             # use same precision for query as for index
@@ -79,10 +76,8 @@ class BruteForceBLAS(BaseANN):
             # argmin_a (a - b)^2 = argmin_a a^2 - 2ab + b^2 = argmin_a a^2 - 2ab
             dists = self.lengths - 2 * numpy.dot(self.index, v)
         elif self._metric == 'hamming':
-            diff = numpy.bitwise_xor(v, self.index)
-            pc = BruteForceBLAS.popcount
-            den = float(len(v) * 8)
-            dists = [sum([pc[part] for part in point]) / den for point in diff]
+            # Just compute hamming distance using euclidean distance
+            dists = self.lengths - 2 * numpy.dot(self.index, v)
         elif self._metric == 'jaccard':
             dists = [pd[self._metric]['distance'](v, e) for e in self.index]
         else:
@@ -92,8 +87,5 @@ class BruteForceBLAS(BaseANN):
         def fix(index):
             ep = self.index[index]
             ev = v
-            if self._metric == "hamming":
-                ep = numpy.unpackbits(ep)
-                ev = numpy.unpackbits(ev)
             return (index, pd[self._metric]['distance'](ep, ev))
         return map(fix, indices)

--- a/ann_benchmarks/algorithms/bruteforce.py
+++ b/ann_benchmarks/algorithms/bruteforce.py
@@ -49,7 +49,7 @@ class BruteForceBLAS(BaseANN):
             self.lengths = numpy.ascontiguousarray(lens, dtype=self._precision)
         elif self._metric == 'hamming':
             self.index = numpy.ascontiguousarray(
-                map(numpy.packbits, X), dtype=numpy.uint8)
+                list(map(numpy.packbits, X)), dtype=numpy.uint8)
         elif self._metric == 'jaccard':
             self.index = X
         else:

--- a/ann_benchmarks/algorithms/nmslib.py
+++ b/ann_benchmarks/algorithms/nmslib.py
@@ -11,7 +11,7 @@ class NmslibReuseIndex(BaseANN):
         return ["%s=%s" % (a, b) for (a, b) in d.iteritems()]
 
     def __init__(self, metric, method_name, index_param, query_param):
-        self._nmslib_metric = {'hamming' : 'cosinesimil', 'angular': 'cosinesimil', 'euclidean': 'l2'}[metric]
+        self._nmslib_metric = {'angular': 'cosinesimil', 'euclidean': 'l2'}[metric]
         self._method_name = method_name
         self._save_index = False
         self._index_param = NmslibReuseIndex.encode(index_param)

--- a/ann_benchmarks/algorithms/nmslib.py
+++ b/ann_benchmarks/algorithms/nmslib.py
@@ -11,7 +11,7 @@ class NmslibReuseIndex(BaseANN):
         return ["%s=%s" % (a, b) for (a, b) in d.iteritems()]
 
     def __init__(self, metric, method_name, index_param, query_param):
-        self._nmslib_metric = {'angular': 'cosinesimil', 'euclidean': 'l2'}[metric]
+        self._nmslib_metric = {'hamming' : 'cosinesimil', 'angular': 'cosinesimil', 'euclidean': 'l2'}[metric]
         self._method_name = method_name
         self._save_index = False
         self._index_param = NmslibReuseIndex.encode(index_param)

--- a/ann_benchmarks/datasets.py
+++ b/ann_benchmarks/datasets.py
@@ -236,7 +236,7 @@ def sift_hamming(out_fn, fn):
         lines = f.readlines()
         X = numpy.zeros((len(lines), 256), dtype=numpy.bool)
         for i, line in enumerate(lines):
-            X[i] = numpy.array([int(x) > 0 for x in line.strip()], dtype=numpy.bool)
+            X[i] = numpy.array([int(x) > 0 for x in line.decode().strip()], dtype=numpy.bool)
         X_train, X_test = train_test_split(X, test_size = 1000)
         write_output(X_train, X_test, out_fn, 'hamming', 'bit')
 

--- a/ann_benchmarks/datasets.py
+++ b/ann_benchmarks/datasets.py
@@ -222,9 +222,23 @@ def word2bits(out_fn, path, fn):
         for i in range(n_words):
             X[i] = numpy.array([float(z) > 0 for z in next(f).strip().split()[1:]], dtype=numpy.bool)
 
-        X_train, X_test = train_test_split(X, test_size=50)
+        X_train, X_test = train_test_split(X, test_size=1000)
         write_output(X_train, X_test, out_fn, 'hamming', 'bit')
 
+def sift_hamming(out_fn, fn):
+    import tarfile
+    local_fn = fn + '.tar.gz'
+    url = 'http://sss.projects.itu.dk/ann-benchmarks/datasets/%s.tar.gz' % fn
+    download(url, local_fn)
+    print('parsing vectors in %s...' % local_fn)
+    with tarfile.open(local_fn, 'r:gz') as t:
+        f = t.extractfile(fn)
+        lines = f.readlines()
+        X = numpy.zeros((len(lines), 256), dtype=numpy.bool)
+        for i, line in enumerate(lines):
+            X[i] = numpy.array([int(x) > 0 for x in line.strip()], dtype=numpy.bool)
+        X_train, X_test = train_test_split(X, test_size = 1000)
+        write_output(X_train, X_test, out_fn, 'hamming', 'bit')
 
 def lastfm(out_fn, n_dimensions, test_size=50000):
     # This tests out ANN methods for retrieval on simple matrix factorization based
@@ -282,4 +296,5 @@ DATASETS = {
     'nytimes-16-angular': lambda out_fn: nytimes(out_fn, 16),
     'word2bits-800-hamming': lambda out_fn: word2bits(out_fn, '400K', 'w2b_bitlevel1_size800_vocab400K'),
     'lastfm-64-dot': lambda out_fn: lastfm(out_fn, 64),
+    'sift-256-hamming': lambda out_fn: sift_hamming(out_fn, 'sift.hamming.256'),
 }

--- a/ann_benchmarks/datasets.py
+++ b/ann_benchmarks/datasets.py
@@ -24,8 +24,14 @@ def get_dataset_fn(dataset):
 
 def get_dataset(which):
     hdf5_fn = get_dataset_fn(which)
-    url = 'http://ann-benchmarks.com/%s.hdf5' % which
-    download(url, hdf5_fn)
+    try:
+        url = 'http://ann-benchmarks.com/%s.hdf5' % which
+        download(url, hdf5_fn)
+    except:
+        print("Cannot download %s" % url)
+        if which in DATASETS:
+            print("Creating dataset locally")
+            DATASETS[which](hdf5_fn)
     hdf5_f = h5py.File(hdf5_fn)
     return hdf5_f
 

--- a/ann_benchmarks/main.py
+++ b/ann_benchmarks/main.py
@@ -105,7 +105,9 @@ def main():
 
     dataset = get_dataset(args.dataset)
     dimension = len(dataset['train'][0]) # TODO(erikbern): ugly
-    point_type = dataset.attrs['point_type']
+    point_type = 'float'
+    if 'point_type' in dataset.attrs:
+        point_type = dataset.attrs['point_type']
     distance = dataset.attrs['distance']
     definitions = get_definitions(args.definitions, dimension, point_type, distance, args.count)
 

--- a/ann_benchmarks/main.py
+++ b/ann_benchmarks/main.py
@@ -105,9 +105,7 @@ def main():
 
     dataset = get_dataset(args.dataset)
     dimension = len(dataset['train'][0]) # TODO(erikbern): ugly
-    point_type = 'float'
-    if 'point_type' in dataset.attrs:
-        point_type = dataset.attrs['point_type']
+    point_type = dataset.attrs.get('point_type', 'float')
     distance = dataset.attrs['distance']
     definitions = get_definitions(args.definitions, dimension, point_type, distance, args.count)
 

--- a/ann_benchmarks/main.py
+++ b/ann_benchmarks/main.py
@@ -105,7 +105,7 @@ def main():
 
     dataset = get_dataset(args.dataset)
     dimension = len(dataset['train'][0]) # TODO(erikbern): ugly
-    point_type = 'float' # TODO(erikbern): should look at the type of X_train
+    point_type = dataset.attrs['point_type']
     distance = dataset.attrs['distance']
     definitions = get_definitions(args.definitions, dimension, point_type, distance, args.count)
 


### PR DESCRIPTION
This PR adds (back) support for bitvectors under Hamming distance. Note that it requires to store the `point_type` within the hdf5 file, so vectors have to be regenerated, @erikbern.

I have added a binary version of the SIFT dataset to it, generated using Spherical hashing. Unfortunately, I don't know of a nice Python implementation of Spherical hashing which would allow producing the binary embedding from SIFT directly from the source (and for other of our datasets as well).

I've tried to add back support for set similarity under Jaccard distance.  Here, each data point is a variable-length set of integers. This turns out to be difficult with the current infrastructure: First, hdf5 doesn't support vectors of `frozenset`s in a straight-forward way. Next, the code becomes really ugly because of the current print outs of the current state including the dimensionality of the vectors, such as:
```python3
 def write_output(train, test, fn, distance, point_type='float', count=100):
       from ann_benchmarks.algorithms.bruteforce import BruteForceBLAS
       n = 0
       f = h5py.File(fn, 'w')
       f.attrs['distance'] = distance
       f.attrs['point_type'] = point_type
       print('train size: %9d * %4d' % train.shape)
       print('test size:  %9d * %4d' % test.shape)
```
For sets, there is no fixed dimensionality and so we would have to distinguish each of the printouts by the type of the dataset at hand. I'm a bit unsure how a nice solution would look like.

PS: This is independent of #84 and both can be merged into each other.