### PR TITLE
Add multiprocessing for building multiple docker images simultaneously

### DIFF
--- a/install.py
+++ b/install.py
@@ -41,9 +41,12 @@ if __name__ == "__main__":
         build(os.getenv('LIBRARY'))
     else:
         print('Building algorithm images... with (%d) processes' % args.proc)
-        pool = Pool(processes=args.proc)
         dockerfiles = []
         for fn in os.listdir('install'):
             if fn.startswith('Dockerfile.'):
                 dockerfiles.append(fn.split('.')[-1])
+
+        pool = Pool(processes=args.proc)
         pool.map(build, dockerfiles)
+        pool.close()
+        pool.join()

--- a/install.py
+++ b/install.py
@@ -18,7 +18,7 @@ if __name__ == "__main__":
         formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument(
         "--proc",
-        default=4,
+        default=1,
         type=positive_int,
         help="the number of process to build docker images")
     parser.add_argument(
@@ -46,7 +46,10 @@ if __name__ == "__main__":
             if fn.startswith('Dockerfile.'):
                 dockerfiles.append(fn.split('.')[-1])
 
-        pool = Pool(processes=args.proc)
-        pool.map(build, dockerfiles)
-        pool.close()
-        pool.join()
+        if args.proc == 1:
+            [build(tag) for tag in dockerfiles]
+        else:
+            pool = Pool(processes=args.proc)
+            pool.map(build, dockerfiles)
+            pool.close()
+            pool.join()

--- a/install.py
+++ b/install.py
@@ -3,17 +3,7 @@ import os
 import argparse
 import subprocess
 from multiprocessing import Pool
-
-
-def positive_int(s):
-    i = None
-    try:
-        i = int(s)
-    except ValueError:
-        pass
-    if not i or i < 1:
-        raise argparse.ArgumentTypeError("%r is not a positive integer" % s)
-    return i
+from ann_benchmarks.main import positive_int
 
 
 def build(library):

--- a/install.py
+++ b/install.py
@@ -1,17 +1,59 @@
 import json
 import os
+import argparse
 import subprocess
+from multiprocessing import Pool
 
-print('Building base image...')
-subprocess.check_call('docker build --rm -t ann-benchmarks -f install/Dockerfile .', shell=True)
+
+def positive_int(s):
+    i = None
+    try:
+        i = int(s)
+    except ValueError:
+        pass
+    if not i or i < 1:
+        raise argparse.ArgumentTypeError("%r is not a positive integer" % s)
+    return i
+
 
 def build(library):
     print('Building %s...' % library)
-    subprocess.check_call('docker build --rm -t ann-benchmarks-%s -f install/Dockerfile.%s .' % (library, library), shell=True)
+    subprocess.check_call(
+        'docker build \
+        --rm -t ann-benchmarks-%s -f install/Dockerfile.%s .' % (library, library), shell=True)
 
-if os.getenv('LIBRARY'):
-    build(os.getenv('LIBRARY'))
-else:
-    for fn in os.listdir('install'):
-        if fn.startswith('Dockerfile.'):
-            build(fn.split('.')[-1])
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument(
+        "--proc",
+        default=4,
+        type=positive_int,
+        help="the number of process to build docker images")
+    parser.add_argument(
+        '--algorithm',
+        metavar='NAME',
+        help='build only the named algorithm image',
+        default=None)
+    args = parser.parse_args()
+
+    print('Building base image...')
+    subprocess.check_call(
+        'docker build \
+        --rm -t ann-benchmarks -f install/Dockerfile .', shell=True)
+
+    if args.algorithm:
+        print('Building algorithm(%s) image...' % args.algorithm)
+        build(args.algorithm)
+    elif os.getenv('LIBRARY'):
+        print('Building algorithm(%s) image...' % os.getenv('LIBRARY'))
+        build(os.getenv('LIBRARY'))
+    else:
+        print('Building algorithm images... with (%d) processes' % args.proc)
+        pool = Pool(processes=args.proc)
+        dockerfiles = []
+        for fn in os.listdir('install'):
+            if fn.startswith('Dockerfile.'):
+                dockerfiles.append(fn.split('.')[-1])
+        pool.map(build, dockerfiles)


### PR DESCRIPTION
- Add `--proc` option for setting multiprocessing pool to build docker
images faster
- Add `--algorithm` option seeming like `LIBRARY` environment
- Remain `LIBRARY` env option but `--algorithm` option has higher priority