### PR TITLE
install swig for faiss

### DIFF
--- a/install/Dockerfile.faiss
+++ b/install/Dockerfile.faiss
@@ -1,6 +1,6 @@
 FROM ann-benchmarks
 
-RUN apt-get update && apt-get install -y libopenblas-base libopenblas-dev libpython-dev python-numpy python-pip
+RUN apt-get update && apt-get install -y libopenblas-base libopenblas-dev libpython-dev python-numpy python-pip swig
 RUN git clone https://github.com/facebookresearch/faiss lib-faiss
 RUN cd lib-faiss && git checkout tags/v1.2.1 -b lib-faiss && cp example_makefiles/makefile.inc.Linux makefile.inc && make -j4 py BLASLDFLAGS=/usr/lib/x86_64-linux-gnu/libopenblas.so.0
 ENV PYTHONPATH lib-faiss


### PR DESCRIPTION
Seems like Faiss has been a bit flaky lately in Travis, and I see it's failing because swig is missing. No idea why it works sometimes.