### PR TITLE
Add autotuning and update proper parameters for MRPT

### DIFF
--- a/algos.yaml
+++ b/algos.yaml
@@ -284,10 +284,10 @@ float:
       constructor: MRPT
       base-args: ["@metric"]
       run-groups:
-        # See https://github.com/ejaasaari/mrpt-comparison/blob/master/parameters/gist.sh
         mrpt:
-          args: [[5, 25, 100], [1, 2, 4, 8]]
-          query-args: [[1, 2, 4, 10, 20, 40, 100]]
+          args: ["@count"]
+          query-args: [[0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.85, 0.9,
+                        0.925, 0.95, 0.97, 0.98, 0.99, 0.995]]
   euclidean:
     kgraph:
       docker-tag: ann-benchmarks-kgraph

--- a/ann_benchmarks/algorithms/mrpt.py
+++ b/ann_benchmarks/algorithms/mrpt.py
@@ -19,6 +19,7 @@ class MRPT(BaseANN):
     def set_query_arguments(self, target_recall):
         self._target_recall = target_recall
         self._index = self._index_autotuned.subset(target_recall)
+        self._par = self._index.parameters()
 
     def query(self, v, n):
         if self._metric == 'angular':
@@ -27,4 +28,5 @@ class MRPT(BaseANN):
         return self._index.ann(v)
 
     def __str__(self):
-        return 'MRPT(target recall = %.3f)' % (self._target_recall)
+        return 'MRPT(target recall=%.3f, trees=%d, depth=%d, vote threshold=%d, estimated recall=%.3f)' % (self._target_recall,
+         self._par['n_trees'], self._par['depth'], self._par['votes'], self._par['estimated_recall'])

--- a/ann_benchmarks/algorithms/mrpt.py
+++ b/ann_benchmarks/algorithms/mrpt.py
@@ -10,6 +10,8 @@ class MRPT(BaseANN):
         self._k = count
 
     def fit(self, X):
+        if X.dtype != numpy.float32:
+            X = X.astype(numpy.float32)
         if self._metric == 'angular':
             X = sklearn.preprocessing.normalize(X, axis=1, norm='l2')
 
@@ -22,10 +24,12 @@ class MRPT(BaseANN):
         self._par = self._index.parameters()
 
     def query(self, v, n):
+        if v.dtype != numpy.float32:
+            v = v.astype(numpy.float32)
         if self._metric == 'angular':
-            v /= numpy.linalg.norm(v)
-
+            v = sklearn.preprocessing.normalize(v.reshape(1,-1), axis=1, norm='l2').flatten()
         return self._index.ann(v)
+
 
     def __str__(self):
         return 'MRPT(target recall=%.3f, trees=%d, depth=%d, vote threshold=%d, estimated recall=%.3f)' % (self._target_recall,

--- a/ann_benchmarks/algorithms/mrpt.py
+++ b/ann_benchmarks/algorithms/mrpt.py
@@ -5,27 +5,26 @@ import mrpt
 from ann_benchmarks.algorithms.base import BaseANN
 
 class MRPT(BaseANN):
-    def __init__(self, metric, n_trees, depth):
+    def __init__(self, metric, count):
         self._metric = metric
-        self._n_trees = n_trees
-        self._depth = depth
-        self._votes_required = None
+        self._k = count
 
     def fit(self, X):
         if self._metric == 'angular':
             X = sklearn.preprocessing.normalize(X, axis=1, norm='l2')
 
-        self._index = mrpt.MRPTIndex(X, depth=self._depth, n_trees=self._n_trees)
-        self._index.build()
+        self._index_autotuned = mrpt.MRPTIndex(X)
+        self._index_autotuned.build_autotune_sample(target_recall = None, k = self._k, n_test = 1000)
 
-    def set_query_arguments(self, votes_required):
-        self._votes_required = votes_required
+    def set_query_arguments(self, target_recall):
+        self._target_recall = target_recall
+        self._index = self._index_autotuned.subset(target_recall)
 
     def query(self, v, n):
         if self._metric == 'angular':
             v /= numpy.linalg.norm(v)
 
-        return self._index.ann(v, n, votes_required=self._votes_required)
+        return self._index.ann(v)
 
     def __str__(self):
-        return 'MRPT(n_trees=%d, depth=%d, votes_required=%d)' % (self._n_trees, self._depth, self._votes_required)
+        return 'MRPT(target recall = %.3f)' % (self._target_recall)

--- a/install/Dockerfile.mrpt
+++ b/install/Dockerfile.mrpt
@@ -1,4 +1,4 @@
 FROM ann-benchmarks
 
 RUN pip3 install sklearn
-RUN pip3 install git+https://github.com/teemupitkanen/mrpt
+RUN pip3 install git+https://github.com/vioshyvo/mrpt


### PR DESCRIPTION
We updated the benchmarking code of MRPT to match a new version of MRPT which has automatic tuning of hyperparameters. This speeds up benchmarking significantly, since there is no need to perform a grid search over 3 hyperparameters anymore.  

The parameters currently used for MRPT are really suboptimal: maximum number of trees 100 and maximum depth is 8, but for larger datasets, such as SIFT and GIST, the optimal number of trees is usually on the range 200-1000, and the optimal depth on the range 8-12. This PR also fixes this.

Now MRPT also works for angular distance (see comments on #83). The problem was in our python bindings.