### PR TITLE
Remove duplicates when creating nytimes data set

### DIFF
--- a/ann_benchmarks/datasets.py
+++ b/ann_benchmarks/datasets.py
@@ -197,6 +197,7 @@ def transform_bag_of_words(filename, n_dimensions, out_fn):
         B = TfidfTransformer().fit_transform(A)
         print("reducing dimensionality...")
         C = random_projection.GaussianRandomProjection(n_components = n_dimensions).fit_transform(B)
+        C = numpy.unique(C, axis = 0) # remove duplicates
         X_train, X_test = train_test_split(C)
         write_output(numpy.array(X_train), numpy.array(X_test), out_fn, 'angular')
 


### PR DESCRIPTION
There are over 40000 duplicates in the original nytimes data set. This makes it not a very good benchmark data set, since on the one hand these would probably be removed in normal preprocessing, and on the other hand if there are more than k duplicates for a query point, the indices of k nearest neighbours are not uniquely determined anymore.

So I propose that we just remove the duplicates when creating the data set.

This would also fix #73. 