### PR TITLE
Small changes to metrics computation + additional metrics

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ before_install:
 script:
   - python run.py --docker-tag ann-benchmarks-${LIBRARY} --max-n-algorithms 5 --dataset $DATASET --run-disabled
   - python run.py --docker-tag ann-benchmarks-${LIBRARY} --max-n-algorithms 5 --dataset $DATASET --run-disabled --batch
-  - python plot.py --dataset $DATASET --output plot.png
-  - python plot.py --dataset $DATASET --output plot-batch.png --batch
+  - sudo python plot.py --dataset $DATASET --output plot.png
+  - sudo python plot.py --dataset $DATASET --output plot-batch.png --batch
   - python -m unittest test/test-metrics.py
-  - python create_website.py --outputdir . --scatter --latex
+  - sudo python create_website.py --outputdir . --scatter --latex

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,8 @@ before_install:
 script:
   - python run.py --docker-tag ann-benchmarks-${LIBRARY} --max-n-algorithms 5 --dataset $DATASET --run-disabled
   - python run.py --docker-tag ann-benchmarks-${LIBRARY} --max-n-algorithms 5 --dataset $DATASET --run-disabled --batch
-  - sudo python plot.py --dataset $DATASET --output plot.png
-  - sudo python plot.py --dataset $DATASET --output plot-batch.png --batch
+  - sudo chmod -R 777 results/
+  - python plot.py --dataset $DATASET --output plot.png
+  - python plot.py --dataset $DATASET --output plot-batch.png --batch
   - python -m unittest test/test-metrics.py
-  - sudo python create_website.py --outputdir . --scatter --latex
+  - python create_website.py --outputdir . --scatter --latex

--- a/ann_benchmarks/algorithms/base.py
+++ b/ann_benchmarks/algorithms/base.py
@@ -23,5 +23,8 @@ class BaseANN(object):
     def get_batch_results(self):
         return self.res
 
+    def get_additional(self):
+        return {}
+
     def __str__(self):
         return self.name

--- a/ann_benchmarks/algorithms/faiss.py
+++ b/ann_benchmarks/algorithms/faiss.py
@@ -64,8 +64,13 @@ class FaissIVF(Faiss):
         self.index = index
 
     def set_query_arguments(self, n_probe):
+        faiss.cvar.indexIVF_stats.reset()
         self._n_probe = n_probe
         self.index.nprobe = self._n_probe
+
+    def get_additional(self):
+        return {"dist_comps" : faiss.cvar.indexIVF_stats.ndis +
+                  faiss.cvar.indexIVF_stats.nq * self._n_list}
 
     def __str__(self):
         return 'FaissIVF(n_list=%d, n_probe=%d)' % (self._n_list, self._n_probe)

--- a/ann_benchmarks/algorithms/faiss_hnsw.py
+++ b/ann_benchmarks/algorithms/faiss_hnsw.py
@@ -27,7 +27,11 @@ class FaissHNSW(Faiss):
         faiss.omp_set_num_threads(1)
 
     def set_query_arguments(self, ef):
+        faiss.cvar.hnsw_stats.reset()
         self.index.hnsw.efSearch = ef
+
+    def get_additional(self):
+        return {"dist_comps" : faiss.cvar.hnsw_stats.ndis}
 
     def freeIndex(self):
         del self.p

--- a/ann_benchmarks/plotting/metrics.py
+++ b/ann_benchmarks/plotting/metrics.py
@@ -1,31 +1,64 @@
 from __future__ import absolute_import
+import numpy as np
 
-def knn(dataset_distances, run_distances, count, epsilon=1e-10):
+def get_recall_values(dataset_distances, run_distances, count, threshold):
     total = len(run_distances) * count
-    actual = 0
-    for true_distances, found_distances in zip(dataset_distances, run_distances):
-        within = [d for d in found_distances[:count] if d <= true_distances[count - 1] + epsilon]
-        actual += len(within)
-    return float(actual) / float(total)
+    recalls = np.zeros(len(run_distances))
+    for i in range(len(run_distances)):
+        t = threshold(dataset_distances[i])
+        actual = 0
+        for j in range(count):
+            if run_distances[i][j] <= t:
+                actual += 1
+            else:
+                break
+        recalls[i] = actual
+    return np.mean(recalls) / float(count), np.std(recalls) / float(count), recalls
 
-def epsilon(dataset_distances, run_distances, count, epsilon=0.01):
-    total = len(run_distances) * count
-    actual = 0
-    for true_distances, found_distances in zip(dataset_distances, run_distances):
-        within = [d for d in found_distances[:count] if d <= true_distances[count - 1] * (1 + epsilon)]
-        actual += len(within)
-    return float(actual) / float(total)
 
-def rel(dataset_distances, run_distances):
-    total_closest_distance = 0.0
-    total_candidate_distance = 0.0
-    for true_distances, found_distances in zip(dataset_distances, run_distances):
-        for rdist, cdist in zip(true_distances, found_distances):
-            total_closest_distance += rdist
-            total_candidate_distance += cdist
-    if total_closest_distance < 0.01:
-        return float("inf")
-    return total_candidate_distance / total_closest_distance
+def knn(dataset_distances, run_distances, count, metrics, epsilon=1e-3):
+    if 'knn' not in metrics:
+        print('Computing knn metrics')
+        knn_metrics = metrics.create_group('knn')
+        mean, std, recalls = get_recall_values(dataset_distances,
+                run_distances, count, lambda l: l[count - 1] + epsilon)
+        knn_metrics.attrs['mean'] = mean
+        knn_metrics.attrs['std'] = std
+        knn_metrics['recalls'] = recalls
+    else:
+        print("Found cached result")
+    return metrics['knn']
+
+def epsilon(dataset_distances, run_distances, count, metrics, epsilon=0.01):
+    s = 'eps' + str(epsilon)
+    if s not in metrics:
+        print('Computing epsilon metrics')
+        epsilon_metrics = metrics.create_group(s)
+        mean, std, recalls = get_recall_values(dataset_distances,
+                run_distances, count, lambda l: l[count - 1] * (1 + epsilon))
+        epsilon_metrics.attrs['mean'] = mean
+        epsilon_metrics.attrs['std'] = std
+        epsilon_metrics['recalls'] = recalls
+    else:
+        print("Found cached result")
+    return metrics[s]
+
+def rel(dataset_distances, run_distances, metrics):
+    if 'rel' not in metrics.attrs:
+        print('Computing rel metrics')
+        total_closest_distance = 0.0
+        total_candidate_distance = 0.0
+        for true_distances, found_distances in zip(dataset_distances, run_distances):
+            for rdist, cdist in zip(true_distances, found_distances):
+                total_closest_distance += rdist
+                total_candidate_distance += cdist
+        if total_closest_distance < 0.01:
+            metrics.attrs['rel'] = float("inf")
+        else:
+            metrics.attrs['rel'] = total_candidate_distance / total_closest_distance
+    else:
+        print("Found cached result")
+    return metrics.attrs['rel']
 
 def queries_per_second(queries, attrs):
     return 1.0 / attrs["best_search_time"]
@@ -40,51 +73,54 @@ def build_time(queries, attrs):
 def candidates(queries, attrs):
     return attrs["candidates"]
 
+def dist_computations(queries, attrs):
+    return attrs.get("dist_comps", 0) / (attrs['run_count'] * len(queries))
+
 all_metrics = {
     "k-nn": {
         "description": "Recall",
-        "function": lambda true_distances, run_distances, run_attrs: knn(true_distances, run_distances, run_attrs["count"]),
+        "function": lambda true_distances, run_distances, metrics, run_attrs: knn(true_distances, run_distances, run_attrs["count"], metrics).attrs['mean'],
         "worst": float("-inf"),
         "lim": [0.0, 1.03]
     },
     "epsilon": {
         "description": "Epsilon 0.01 Recall",
-        "function": lambda true_distances, run_distances, run_attrs: epsilon(true_distances, run_distances, run_attrs["count"]),
+        "function": lambda true_distances, run_distances, metrics, run_attrs: epsilon(true_distances, run_distances, run_attrs["count"], metrics).attrs['mean'],
         "worst": float("-inf")
     },
     "largeepsilon": {
         "description": "Epsilon 0.1 Recall",
-        "function": lambda true_distances, run_distances, run_attrs: epsilon(true_distances, run_distances, run_attrs["count"], 0.1),
+        "function": lambda true_distances, run_distances, metrics, run_attrs: epsilon(true_distances, run_distances, run_attrs["count"], metrics, 0.1).attrs['mean'],
         "worst": float("-inf")
     },
     "rel": {
         "description": "Relative Error",
-        "function": lambda true_distances, run_distances, run_attrs: rel(true_distances, run_distances),
+        "function": lambda true_distances, run_distances, metrics, run_attrs: rel(true_distances, run_distances, metrics),
         "worst": float("inf")
     },
     "qps": {
         "description": "Queries per second (1/s)",
-        "function": lambda true_distances, run_distances, run_attrs: queries_per_second(true_distances, run_attrs),
+        "function": lambda true_distances, run_distances, metrics, run_attrs: queries_per_second(true_distances, run_attrs),
         "worst": float("-inf")
     },
     "build": {
         "description": "Build time (s)",
-        "function": lambda true_distances, run_distances, run_attrs: build_time(true_distances, run_attrs),
+        "function": lambda true_distances, run_distances, metrics, run_attrs: build_time(true_distances, run_attrs),
         "worst": float("inf")
     },
     "candidates" : {
         "description": "Candidates generated",
-        "function": lambda true_distances, run_distances, run_attrs: candidates(true_distances, run_attrs),
+        "function": lambda true_distances, run_distances, metrics, run_attrs: candidates(true_distances, run_attrs),
         "worst": float("inf")
     },
     "indexsize" : {
         "description": "Index size (kB)",
-        "function": lambda true_distances, run_distances, run_attrs: index_size(true_distances, run_attrs),
+        "function": lambda true_distances, run_distances, metrics, run_attrs: index_size(true_distances, run_attrs),
         "worst": float("inf")
     },
     "queriessize" : {
         "description": "Index size (kB)/Queries per second (s)",
-        "function": lambda true_distances, run_distances, run_attrs: index_size(true_distances, run_attrs) / queries_per_second(true_distances, run_attrs),
+        "function": lambda true_distances, run_distances, metrics, run_attrs: index_size(true_distances, run_attrs) / queries_per_second(true_distances, run_attrs),
         "worst": float("inf")
     }
 }

--- a/ann_benchmarks/plotting/metrics.py
+++ b/ann_benchmarks/plotting/metrics.py
@@ -1,13 +1,19 @@
 from __future__ import absolute_import
 import numpy as np
 
-def get_recall_values(dataset_distances, run_distances, count, threshold):
+def knn_threshold(data, count, epsilon):
+    return data[count - 1] + epsilon
+
+def epsilon_threshold(data, count, epsilon):
+    return data[count - 1] * (1 + epsilon)
+
+def get_recall_values(dataset_distances, run_distances, count, threshold, epsilon=1e-3):
     total = len(run_distances) * count
     recalls = np.zeros(len(run_distances))
     for i in range(len(run_distances)):
-        t = threshold(dataset_distances[i])
+        t = threshold(dataset_distances[i], count, epsilon)
         actual = 0
-        for j in range(count):
+        for j in range(min(count, len(run_distances[i]))):
             if run_distances[i][j] <= t:
                 actual += 1
             else:
@@ -21,7 +27,7 @@ def knn(dataset_distances, run_distances, count, metrics, epsilon=1e-3):
         print('Computing knn metrics')
         knn_metrics = metrics.create_group('knn')
         mean, std, recalls = get_recall_values(dataset_distances,
-                run_distances, count, lambda l: l[count - 1] + epsilon)
+                run_distances, count, knn_threshold, epsilon)
         knn_metrics.attrs['mean'] = mean
         knn_metrics.attrs['std'] = std
         knn_metrics['recalls'] = recalls
@@ -35,7 +41,7 @@ def epsilon(dataset_distances, run_distances, count, metrics, epsilon=0.01):
         print('Computing epsilon metrics')
         epsilon_metrics = metrics.create_group(s)
         mean, std, recalls = get_recall_values(dataset_distances,
-                run_distances, count, lambda l: l[count - 1] * (1 + epsilon))
+                run_distances, count, epsilon_threshold, epsilon)
         epsilon_metrics.attrs['mean'] = mean
         epsilon_metrics.attrs['std'] = std
         epsilon_metrics['recalls'] = recalls

--- a/ann_benchmarks/plotting/metrics.py
+++ b/ann_benchmarks/plotting/metrics.py
@@ -103,6 +103,11 @@ all_metrics = {
         "function": lambda true_distances, run_distances, metrics, run_attrs: queries_per_second(true_distances, run_attrs),
         "worst": float("-inf")
     },
+    "distcomps" : {
+        "description": "Distance computations",
+        "function": lambda true_distances, run_distances,  metrics, run_attrs: dist_computations(true_distances, run_attrs),
+        "worst": float("inf")
+    },
     "build": {
         "description": "Build time (s)",
         "function": lambda true_distances, run_distances, metrics, run_attrs: build_time(true_distances, run_attrs),

--- a/ann_benchmarks/plotting/metrics.py
+++ b/ann_benchmarks/plotting/metrics.py
@@ -13,14 +13,11 @@ def get_recall_values(dataset_distances, run_distances, count, threshold, epsilo
     for i in range(len(run_distances)):
         t = threshold(dataset_distances[i], count, epsilon)
         actual = 0
-        for j in range(min(count, len(run_distances[i]))):
-            if run_distances[i][j] <= t:
+        for d in run_distances[i][:count]:
+            if d <= t:
                 actual += 1
-            else:
-                break
         recalls[i] = actual
     return np.mean(recalls) / float(count), np.std(recalls) / float(count), recalls
-
 
 def knn(dataset_distances, run_distances, count, metrics, epsilon=1e-3):
     if 'knn' not in metrics:

--- a/ann_benchmarks/plotting/plot_variants.py
+++ b/ann_benchmarks/plotting/plot_variants.py
@@ -4,6 +4,7 @@ all_plot_variants = {
     "recall/time" : ("k-nn", "qps"),
     "recall/buildtime" : ("k-nn", "build"),
     "recall/indexsize" : ("k-nn", "indexsize"),
+    "recall/distcomps" : ("k-nn", "distcomps"),
     "rel/time" : ("rel", "qps"),
     "recall/candidates" : ("k-nn", "candidates"),
     "recall/qpssize" : ("k-nn", "queriessize"),

--- a/ann_benchmarks/results.py
+++ b/ann_benchmarks/results.py
@@ -48,7 +48,7 @@ def load_all_results(dataset=None, count=None, split_batched=False,  batch_mode=
             try:
                 if split_batched and batch_mode != is_batch(root):
                     continue
-                f = h5py.File(os.path.join(root, fn))
+                f = h5py.File(os.path.join(root, fn), 'r+')
                 properties = dict(f.attrs)
                 # TODO Fix this properly. Sometimes the hdf5 file returns bytes
                 # This converts these bytes to strings before we work with them

--- a/ann_benchmarks/runner.py
+++ b/ann_benchmarks/runner.py
@@ -93,6 +93,9 @@ def run_individual_query(algo, X_train, X_test, distance, count, run_count, batc
         "distance": distance,
         "count": int(count)
     }
+    additional = algo.get_additional()
+    for k in additional:
+        attrs[k] = additional[k]
     return (attrs, results)
 
 

--- a/create_website.py
+++ b/create_website.py
@@ -95,6 +95,10 @@ parser.add_argument(
     '--scatter',
     help='create scatterplot for data',
     action = 'store_true')
+parser.add_argument(
+    '--recompute',
+    help='Clears the cache and recomputes the metrics',
+    action='store_true')
 args = parser.parse_args()
 
 def get_lines(all_data, xn, yn, render_all_points):
@@ -189,7 +193,7 @@ def load_all_results():
             cached_true_dist = list(dataset["distances"])
             old_sdn = sdn
         algo = properties["algo"]
-        ms = compute_all_metrics(cached_true_dist, f, properties)
+        ms = compute_all_metrics(cached_true_dist, f, properties, args.recompute)
         algo_ds = get_dataset_label(sdn)
         idx = "non-batch"
         if properties["batch_mode"]:

--- a/install/Dockerfile.flann
+++ b/install/Dockerfile.flann
@@ -1,6 +1,6 @@
 FROM ann-benchmarks
 
-RUN apt-get update && apt-get install -y cmake
+RUN apt-get update && apt-get install -y cmake pkg-config liblz4-dev
 RUN git clone https://github.com/mariusmuja/flann
 RUN mkdir flann/build
 RUN cd flann/build && cmake ..

--- a/plot.py
+++ b/plot.py
@@ -2,6 +2,7 @@ import os
 import matplotlib as mpl
 mpl.use('Agg')
 import matplotlib.pyplot as plt
+import numpy as np
 import argparse
 
 from ann_benchmarks.datasets import get_dataset
@@ -90,6 +91,10 @@ if __name__ == "__main__":
         '--batch',
         help='Plot runs in batch mode',
         action='store_true')
+    parser.add_argument(
+        '--recompute',
+        help='Clears the cache and recomputes the metrics',
+        action='store_true')
     args = parser.parse_args()
 
     if not args.output:
@@ -101,7 +106,8 @@ if __name__ == "__main__":
     unique_algorithms = get_unique_algorithms()
     results = load_all_results(args.dataset, count, True, args.batch)
     linestyles = create_linestyles(sorted(unique_algorithms))
-    runs = compute_metrics(list(dataset["distances"]), results, args.x_axis, args.y_axis)
+    runs = compute_metrics(np.array(dataset["distances"]),
+            results, args.x_axis, args.y_axis, args.recompute)
     if not runs:
         raise Exception('Nothing to plot')
 

--- a/test/test-metrics.py
+++ b/test/test-metrics.py
@@ -1,6 +1,25 @@
 import unittest
 from ann_benchmarks.plotting.metrics import knn, queries_per_second,\
-        index_size, build_time, candidates, epsilon, rel
+        index_size, build_time, candidates, epsilon, rel, all_metrics
+
+class DummyMetric():
+
+    def __init__(self):
+        self.attrs = {}
+        self.d = {}
+
+    def __getitem__(self, key):
+        return self.d.get(key, None)
+
+    def __setitem__(self, key, value):
+        self.d[key] = value
+
+    def __contains__(self, key):
+        return key in self.d
+
+    def create_group(self, name):
+        self.d[name] = DummyMetric()
+        return self.d[name]
 
 class TestMetrics(unittest.TestCase):
 
@@ -14,23 +33,23 @@ class TestMetrics(unittest.TestCase):
         run3 = [[0.2]]
         run4 = [[0.2, 0.25]]
 
-        self.assertAlmostEqual(knn(exact_queries, run1, 2), 0.0)
-        self.assertAlmostEqual(knn(exact_queries, run2, 2), 0.5)
-        self.assertAlmostEqual(knn(exact_queries, run3, 2), 0.5)
-        self.assertAlmostEqual(knn(exact_queries, run4, 2), 1.0)
+        self.assertAlmostEqual(knn(exact_queries, run1, 2, DummyMetric()).attrs['mean'], 0.0)
+        self.assertAlmostEqual(knn(exact_queries, run2, 2, DummyMetric()).attrs['mean'], 0.5)
+        self.assertAlmostEqual(knn(exact_queries, run3, 2, DummyMetric()).attrs['mean'], 0.5)
+        self.assertAlmostEqual(knn(exact_queries, run4, 2, DummyMetric()).attrs['mean'], 1.0)
 
     def test_epsilon_recall(self):
         exact_queries = [[0.05, 0.08, 0.24, 0.3]]
         run1 = [[]]
         run2 = [[0.1, 0.2, 0.55, 0.7]]
 
-        self.assertAlmostEqual(epsilon(exact_queries, run1, 4, 1), 0.0)
+        self.assertAlmostEqual(epsilon(exact_queries, run1, 4, DummyMetric(), 1).attrs['mean'], 0.0)
 
-        self.assertAlmostEqual(epsilon(exact_queries, run2, 4, 0.0001), 0.5)
+        self.assertAlmostEqual(epsilon(exact_queries, run2, 4, DummyMetric(), 0.0001).attrs['mean'], 0.5)
         # distance can be off by factor (1 + 1) * 0.3 = 0.6 => recall .75
-        self.assertAlmostEqual(epsilon(exact_queries, run2, 4, 1), 0.75)
+        self.assertAlmostEqual(epsilon(exact_queries, run2, 4, DummyMetric(), 1).attrs['mean'], 0.75)
         # distance can be off by factor (1 + 2) * 0.3 = 0.9 => recall 1
-        self.assertAlmostEqual(epsilon(exact_queries, run2, 4, 2), 1.0)
+        self.assertAlmostEqual(epsilon(exact_queries, run2, 4, DummyMetric(), 2).attrs['mean'], 1.0)
 
     def test_relative(self):
         exact_queries = [[0.1, 0.2, 0.25, 0.3]]
@@ -38,10 +57,10 @@ class TestMetrics(unittest.TestCase):
         run2 = [[0.1, 0.2, 0.25, 0.3]]
         run3 = [[0.1, 0.2, 0.55, 0.9]]
 
-        self.assertAlmostEqual(rel(exact_queries, run1), float("inf"))
-        self.assertAlmostEqual(rel(exact_queries, run2), 1)
+        self.assertAlmostEqual(rel(exact_queries, run1, DummyMetric()), float("inf"))
+        self.assertAlmostEqual(rel(exact_queries, run2, DummyMetric()), 1)
         # total distance exact: 0.85, total distance run3: 1.75
-        self.assertAlmostEqual(rel(exact_queries, run3), 1.75 /
+        self.assertAlmostEqual(rel(exact_queries, run3, DummyMetric()), 1.75 /
                 0.85)
 
     def test_queries_per_second(self):


### PR DESCRIPTION
This PR makes the following changes:

- Added mechanism to allow an implementation to report on additional characteristics. This is showcast by having IVF and HNSW (from faiss) report the number of distance computations done to answer the set of queries (which is a general benchmark of the quality more independent than running times).
- Small refactorings in metric computation, report not only on avg but also standard deviation. (To be later added as error bars in plots.)
- Store computed metrics inside the result file to avoid recomputation
- Improved plotting time by a factor ~4 by better caching of hdf5 access and small changes to the metric computation

The general goal of these changes is to make it easier to work with our result files, e.g. for visualization of results beyond those provided at the moment.  

We use it to create plots like this, which provide more inside into what the distribution of individual recall values looks compared to the average (the single dot):
![image](https://user-images.githubusercontent.com/6311646/53883388-26279880-4019-11e9-9332-4682711b4a43.png)


This gives more details into the inner workings of different algorithmic ideas. (To be discussed:  should such plottings scripts be added to ann-benchmarks as well?)