### PR TITLE
Updated SPTAG docker file

### DIFF
--- a/algos.yaml
+++ b/algos.yaml
@@ -1,5 +1,14 @@
 float:
   any:
+    sptag:
+      docker-tag: ann-benchmarks-sptag
+      module: ann_benchmarks.algorithms.sptag
+      constructor: Sptag
+      base-args: ["@metric"]
+      run-groups:
+        sptag:
+          args: [['BKT', 'KDT']]
+          query-args: [[100, 200, 400, 1000, 2000, 4000]]
     DolphinnPy:
       disabled: true
       docker-tag: ann-benchmarks-dolphinn # Docker tag
@@ -451,15 +460,6 @@ float:
         pynndescent:
           args: [[5, 10, 20, 40, 80, 160], [8], [40]]
           query-args: [[1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0]]
-    sptag:
-      docker-tag: ann-benchmarks-sptag
-      module: ann_benchmarks.algorithms.sptag
-      constructor: Sptag
-      base-args: ["@metric"]
-      run-groups:
-        sptag:
-          args: [['BKT', 'KDT']]
-          query-args: [[100, 200, 400, 1000, 2000, 4000]]
 bit:
   hamming:
     mih:

--- a/ann_benchmarks/algorithms/sptag.py
+++ b/ann_benchmarks/algorithms/sptag.py
@@ -5,7 +5,7 @@ from ann_benchmarks.algorithms.base import BaseANN
 
 class Sptag(BaseANN):
     def __init__(self, metric, algo):
-        self._algo = algo
+        self._algo = str(algo)
         self._metric = {
             'angular': 'Cosine', 'euclidean': 'L2'}[metric]
 

--- a/install/Dockerfile.sptag
+++ b/install/Dockerfile.sptag
@@ -2,27 +2,22 @@ FROM ann-benchmarks
 
 RUN git clone https://github.com/microsoft/SPTAG
 
-RUN apt-get update && apt-get -y install wget build-essential libtbb-dev \
+RUN apt-get update && apt-get -y install wget build-essential libtbb-dev software-properties-common \
     # remove the following if you don't want to build the wrappers
-    openjdk-8-jdk python3-pip swig
+    python-pip swig
 
 # cmake >= 3.12 is required
 RUN wget "https://github.com/Kitware/CMake/releases/download/v3.14.4/cmake-3.14.4-Linux-x86_64.tar.gz" -q -O - \
         | tar -xz --strip-components=1 -C /usr/local
 
-# specific version of boost
-RUN wget "https://dl.bintray.com/boostorg/release/1.67.0/source/boost_1_67_0.tar.gz" -q -O - \
-        | tar -xz && \
-        cd boost_1_67_0 && \
-        ./bootstrap.sh && \
-        ./b2 install && \
-        # update ld cache so it finds boost in /usr/local/lib
-        ldconfig && \
-        cd .. && rm -rf boost_1_67_0
+RUN add-apt-repository 'deb http://archive.ubuntu.com/ubuntu disco main universe' && apt-get update && apt-get -y install libboost1.67-all-dev
 
 # build
 RUN cd SPTAG && mkdir build && cd build && cmake .. && make && cd ..
 
 # so python can find the SPTAG module
 ENV PYTHONPATH=/home/app/SPTAG/Release
-RUN python3 -c 'import SPTAG'
+RUN python -c 'import SPTAG'
+RUN pip install -r requirements.txt
+RUN pip install sklearn enum34
+ENTRYPOINT ["python", "run_algorithm.py"]


### PR DESCRIPTION
As discussed in #119, this PR makes SPTAG use the libboost1.67-dev-all package instead of building boost itself.

libboost-dev-all comes with a Python 2 dependency, which is the preferred Python version in SPTAG's build system. Thus I changed the entry point to run with Python 2.