### PR TITLE
Fix naming of Faiss' HNSW and SPTAG.

### DIFF
--- a/ann_benchmarks/algorithms/faiss_hnsw.py
+++ b/ann_benchmarks/algorithms/faiss_hnsw.py
@@ -11,7 +11,6 @@ class FaissHNSW(Faiss):
     def __init__(self, metric, method_param):
         self._metric = metric
         self.method_param = method_param
-        self.name = 'faiss (%s)' % (self.method_param)
 
     def fit(self, X):
         self.index = faiss.IndexHNSWFlat(len(X[0]), self.method_param["M"])
@@ -32,6 +31,9 @@ class FaissHNSW(Faiss):
 
     def get_additional(self):
         return {"dist_comps": faiss.cvar.hnsw_stats.ndis}
+
+    def __str__(self):
+        return 'faiss (%s, ef: %d)' % (self.method_param, self.index.hnsw.efSearch)
 
     def freeIndex(self):
         del self.p

--- a/ann_benchmarks/algorithms/sptag.py
+++ b/ann_benchmarks/algorithms/sptag.py
@@ -13,15 +13,16 @@ class Sptag(BaseANN):
         self._sptag = SPTAG.AnnIndex(self._algo, 'Float', X.shape[1])
         self._sptag.SetBuildParam("NumberOfThreads", '32')
         self._sptag.SetBuildParam("DistCalcMethod", self._metric)
-        self._sptag.Build(X.tobytes(), X.shape[0])
+        self._sptag.Build(X, X.shape[0])
 
     def set_query_arguments(self, MaxCheck):
-        self._sptag.SetSearchParam("MaxCheck", str(MaxCheck))
+        self._maxCheck = MaxCheck
+        self._sptag.SetSearchParam("MaxCheck", str(self._maxCheck))
 
     def query(self, v, k):
-        return self._sptag.Search(v.tobytes(), k)[0]
+        return self._sptag.Search(v, k)[0]
 
     def __str__(self):
-        return 'Sptag(metric=%s, algo=%s)' % (self._metric,
-                                              self._algo)
+        return 'Sptag(metric=%s, algo=%s, check=%d)' % (self._metric,
+                                              self._algo, self._maxCheck)
 


### PR DESCRIPTION
Adds a missing query parameter to the name in the result file. Currently we cannot say which query parameter gave a particular data point.