### PR TITLE
Reintroduce Set Similarity under Jaccard Distance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ env:
   - LIBRARY=sklearn DATASET=random-xs-20-angular
   - LIBRARY=sptag DATASET=random-xs-20-angular
   - LIBRARY=mih DATASET=random-xs-16-hamming
+  - LIBRARY=datasketch DATASET=random-s-jaccard
 
 before_install:
   - pip install -r requirements.txt
@@ -38,4 +39,5 @@ script:
   - python plot.py --dataset $DATASET --output plot.png
   - python plot.py --dataset $DATASET --output plot-batch.png --batch
   - python -m unittest test/test-metrics.py
+  - python -m unittest test/test-jaccard.py
   - python create_website.py --outputdir . --scatter --latex

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ We have a number of precomputed data sets for this. All data sets are pre-split 
 | GloVe                                                             |         50 |  1,183,514 |    10,000 |       100 | Angular   | [HDF5](http://ann-benchmarks.com/glove-50-angular.hdf5) (235MB)            |
 | GloVe                                                             |        100 |  1,183,514 |    10,000 |       100 | Angular   | [HDF5](http://ann-benchmarks.com/glove-100-angular.hdf5) (463MB)           |
 | GloVe                                                             |        200 |  1,183,514 |    10,000 |       100 | Angular   | [HDF5](http://ann-benchmarks.com/glove-200-angular.hdf5) (918MB)           |
+| [Kosarak](http://fimi.uantwerpen.be/data/)                        |      27983 |     74,962 |       500 |       100 | Jaccard   | [HDF5](http://ann-benchmarks.com/kosarak-jaccard.hdf5) (2.0GB)             |
 | [MNIST](http://yann.lecun.com/exdb/mnist/)                        |        784 |     60,000 |    10,000 |       100 | Euclidean | [HDF5](http://ann-benchmarks.com/mnist-784-euclidean.hdf5) (217MB)         |
 | [NYTimes](https://archive.ics.uci.edu/ml/datasets/bag+of+words)   |        256 |    290,000 |    10,000 |       100 | Angular   | [HDF5](http://ann-benchmarks.com/nytimes-256-angular.hdf5) (301MB)         |
 | [SIFT](https://corpus-texmex.irisa.fr/)                           |        128 |  1,000,000 |    10,000 |       100 | Euclidean | [HDF5](http://ann-benchmarks.com/sift-128-euclidean.hdf5) (501MB)          |

--- a/algos.yaml
+++ b/algos.yaml
@@ -554,7 +554,6 @@ bit:
         base:
           args: [[32,64,128,256,512,1024,2048,4096,8192]]
           query-args: [[1, 5, 10, 50, 100, 200]]
-bit:
   jaccard:
     bf:
       docker-tag: ann-benchmarks-sklearn

--- a/algos.yaml
+++ b/algos.yaml
@@ -554,7 +554,7 @@ bit:
         base:
           args: [[32,64,128,256,512,1024,2048,4096,8192]]
           query-args: [[1, 5, 10, 50, 100, 200]]
-int:
+bit:
   jaccard:
     bf:
       docker-tag: ann-benchmarks-sklearn
@@ -571,4 +571,16 @@ int:
       base-args: ["@metric"]
       run-groups:
         base:
-          args:  [[16, 32, 64, 128],[5, 10, 20, 40]]
+          args:  [[128, 256, 512],[8, 16, 32, 64, 128]]
+    puffinn:
+      docker-tag: ann-benchmarks-puffinn
+      module: ann_benchmarks.algorithms.puffinn
+      constructor: Puffinn
+      base-args: ["@metric"]
+      run-groups:
+        base:
+            args: [
+              [ 16000000, 512000000],
+              ['1bit_minhash'],
+            ]
+            query-args: [[0.1, 0.2, 0.5, 0.7, 0.9, 0.95, 0.99]]

--- a/ann_benchmarks/algorithms/datasketch.py
+++ b/ann_benchmarks/algorithms/datasketch.py
@@ -18,12 +18,12 @@ class DataSketch(BaseANN):
         for i, x in enumerate(X):
             m = MinHash(num_perm=self._n_perm)
             for e in x:
-                m.update(str(e))
+                m.update(str(e).encode('utf8'))
             self._index.add(str(i), m)
         self._index.index()
 
     def query(self, v, n):
         m = MinHash(num_perm=self._n_perm)
         for e in v:
-            m.update(str(e))
+            m.update(str(e).encode('utf8'))
         return map(int, self._index.query(m, n))

--- a/ann_benchmarks/datasets.py
+++ b/ann_benchmarks/datasets.py
@@ -8,6 +8,8 @@ try:
 except ImportError:
     from urllib.request import urlretrieve  # Python 3
 
+from ann_benchmarks.distance import dataset_transform
+
 
 def download(src, dst):
     if not os.path.exists(dst):
@@ -55,11 +57,13 @@ def write_output(train, test, fn, distance, point_type='float', count=100):
     neighbors = f.create_dataset('neighbors', (len(test), count), dtype='i')
     distances = f.create_dataset('distances', (len(test), count), dtype='f')
     bf = BruteForceBLAS(distance, precision=train.dtype)
+    train = dataset_transform[distance](train)
+    test = dataset_transform[distance](test)
     bf.fit(train)
     queries = []
     for i, x in enumerate(test):
         if i % 1000 == 0:
-            print('%d/%d...' % (i, test.shape[0]))
+            print('%d/%d...' % (i, len(test)))
         res = list(bf.query_with_distances(x, count))
         res.sort(key=lambda t: t[-1])
         neighbors[i] = [j for j, _ in res]

--- a/ann_benchmarks/datasets.py
+++ b/ann_benchmarks/datasets.py
@@ -318,6 +318,7 @@ def kosarak(out_fn):
     write_output(X_train, X_test, out_fn, 'jaccard', 'bit')
 
 def random_jaccard(out_fn, n=10000, size=50, universe=80):
+    random.seed(1)
     l = list(range(universe))
     X = numpy.zeros((n, universe), dtype=numpy.bool)
     for i in range(len(X)):

--- a/ann_benchmarks/datasets.py
+++ b/ann_benchmarks/datasets.py
@@ -220,7 +220,7 @@ def nytimes(out_fn, n_dimensions):
     transform_bag_of_words(fn, n_dimensions, out_fn)
 
 
-def random(out_fn, n_dims, n_samples, centers, distance):
+def random_float(out_fn, n_dims, n_samples, centers, distance):
     import sklearn.datasets
 
     X, _ = sklearn.datasets.make_blobs(
@@ -332,13 +332,13 @@ DATASETS = {
     'glove-100-angular': lambda out_fn: glove(out_fn, 100),
     'glove-200-angular': lambda out_fn: glove(out_fn, 200),
     'mnist-784-euclidean': mnist,
-    'random-xs-20-euclidean': lambda out_fn: random(out_fn, 20, 10000, 100,
+    'random-xs-20-euclidean': lambda out_fn: random_float(out_fn, 20, 10000, 100,
                                                     'euclidean'),
-    'random-s-100-euclidean': lambda out_fn: random(out_fn, 100, 100000, 1000,
+    'random-s-100-euclidean': lambda out_fn: random_float(out_fn, 100, 100000, 1000,
                                                     'euclidean'),
-    'random-xs-20-angular': lambda out_fn: random(out_fn, 20, 10000, 100,
+    'random-xs-20-angular': lambda out_fn: random_float(out_fn, 20, 10000, 100,
                                                   'angular'),
-    'random-s-100-angular': lambda out_fn: random(out_fn, 100, 100000, 1000,
+    'random-s-100-angular': lambda out_fn: random_float(out_fn, 100, 100000, 1000,
                                                   'angular'),
     'random-xs-16-hamming': lambda out_fn: random_bitstring(out_fn, 16, 10000,
                                                             100),

--- a/ann_benchmarks/distance.py
+++ b/ann_benchmarks/distance.py
@@ -1,20 +1,38 @@
 from __future__ import absolute_import
 from scipy.spatial.distance import pdist as scipy_pdist
-
+import numpy as np
 
 def pdist(a, b, metric):
     return scipy_pdist([a, b], metric=metric)[0]
 
-# Need own implementation of jaccard because numpy's
+# Need own implementation of jaccard because scipy's
 # implementation is different
-
 
 def jaccard(a, b):
     if len(a) == 0 or len(b) == 0:
-        return 0
-    intersect = len(a & b)
+         return 0
+    intersect = len(set(a) & set(b))
     return intersect / (float)(len(a) + len(b) - intersect)
 
+def transform_dense_to_sparse(X):
+    """Converts the n * m dataset into a sparse format
+    that only holds the non-zero entries (Jaccard)."""
+    # get list of indices of non-zero elements
+    indices = np.transpose(np.where(X))
+    keys = []
+    l = []
+    last_i = None
+    for i, j in indices:
+        if last_i != None and last_i != i:
+            keys.append(l)
+            l = []
+        l.append(j)
+        last_i = i
+    keys.append(l)
+
+    assert len(X) == len(keys)
+
+    return keys
 
 metrics = {
     'hamming': {

--- a/ann_benchmarks/distance.py
+++ b/ann_benchmarks/distance.py
@@ -35,3 +35,10 @@ metrics = {
         'distance_valid': lambda a: True
     }
 }
+
+dataset_transform = {
+    'hamming': lambda X: X,
+    'euclidean': lambda X: X,
+    'angular': lambda X: X,
+    'jaccard' : lambda X: transform_dense_to_sparse(X)
+}

--- a/ann_benchmarks/distance.py
+++ b/ann_benchmarks/distance.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 from scipy.spatial.distance import pdist as scipy_pdist
+import itertools
 import numpy as np
 
 def pdist(a, b, metric):
@@ -20,15 +21,8 @@ def transform_dense_to_sparse(X):
     # get list of indices of non-zero elements
     indices = np.transpose(np.where(X))
     keys = []
-    l = []
-    last_i = None
-    for i, j in indices:
-        if last_i != None and last_i != i:
-            keys.append(l)
-            l = []
-        l.append(j)
-        last_i = i
-    keys.append(l)
+    for _, js in itertools.groupby(indices, lambda ij: ij[0]):
+        keys.append([j for _, j in js])
 
     assert len(X) == len(keys)
 

--- a/ann_benchmarks/runner.py
+++ b/ann_benchmarks/runner.py
@@ -24,7 +24,7 @@ from ann_benchmarks.datasets import get_dataset, DATASETS
 from ann_benchmarks.algorithms.definitions import (Definition,
                                                    instantiate_algorithm,
                                                    get_algorithm_name)
-from ann_benchmarks.distance import metrics
+from ann_benchmarks.distance import metrics, dataset_transform
 from ann_benchmarks.results import store_results
 
 
@@ -56,7 +56,7 @@ def run_individual_query(algo, X_train, X_test, distance, count, run_count,
             n_items_processed[0] += 1
             if n_items_processed[0] % 1000 == 0:
                 print('Processed %d/%d queries...' %
-                      (n_items_processed[0], X_test.shape[0]))
+                      (n_items_processed[0], len(X_test)))
             if len(candidates) > count:
                 print('warning: algorithm %s returned %d results, but count'
                       ' is only %d)' % (algo, len(candidates), count))
@@ -120,6 +120,9 @@ function""" % (definition.module, definition.constructor, definition.arguments)
     distance = D.attrs['distance']
     print('got a train set of size (%d * %d)' % X_train.shape)
     print('got %d queries' % len(X_test))
+
+    X_train = dataset_transform[distance](X_train)
+    X_test = dataset_transform[distance](X_test)
 
     try:
         prepared_queries = False

--- a/test/test-jaccard.py
+++ b/test/test-jaccard.py
@@ -15,6 +15,7 @@ class TestJaccard(unittest.TestCase):
         self.assertAlmostEqual(jaccard(a, b), 0.0)
         self.assertAlmostEqual(jaccard(a, a), 1.0)
         self.assertAlmostEqual(jaccard(a, c), 0.5)
+        self.assertAlmostEqual(jaccard(c, d), 0.0)
 
     def test_transformation(self):
         X = numpy.array([[True, False, False], [True, False, True], [False, False, True]])

--- a/test/test-jaccard.py
+++ b/test/test-jaccard.py
@@ -1,0 +1,22 @@
+import unittest
+import numpy
+from ann_benchmarks.distance import jaccard, transform_dense_to_sparse
+
+class TestJaccard(unittest.TestCase):
+    def setUp(self):
+        pass
+
+    def test_similarity(self):
+        a = [1, 2, 3, 4]
+        b = []
+        c = [1, 2]
+        d = [5, 6]
+
+        self.assertAlmostEqual(jaccard(a, b), 0.0)
+        self.assertAlmostEqual(jaccard(a, a), 1.0)
+        self.assertAlmostEqual(jaccard(a, c), 0.5)
+
+    def test_transformation(self):
+        X = numpy.array([[True, False, False], [True, False, True], [False, False, True]])
+        self.assertEqual(transform_dense_to_sparse(X), [[0],[0, 2], [2]])
+


### PR DESCRIPTION
This PR reintroduces support for ANN for sets under Jaccard similarity. (It always bothered me that we lost support for a 1k star ANN implementation https://github.com/ekzhu/datasketch/.) Currently, there is only one standard data set and some random sets for testing.

I tried to keep the PR as minimally invasive as possible. This means that sets are stored as bit vector representation in hdf5 (because they are supposed to be 2d np matrices), but are then transformed to a sparse list-of-indices representation (needed by the algorithms).

Looking forward to hearing your thoughts!