### PR TITLE
Pynndescent update

### DIFF
--- a/algos.yaml
+++ b/algos.yaml
@@ -266,9 +266,14 @@ float:
       constructor: PyNNDescent
       base-args: ["@metric"]
       run-groups:
-        pynndescent:
-          args: [[10, 20, 40, 80], [4, 8], [30]]
-          query-args: [[1.0, 2.0, 4.0, 8.0]]
+        NN-10-20:
+          arg-groups:
+            - {"n_neighbors": [10, 20], "diversify_epsilon": [1.0], "pruning_degree_multiplier":[1.0, 1.5, 2.0], "leaf_size":32}
+          query-args: [[0.0, 0.02, 0.04, 0.06, 0.08, 0.10, 0.12, 0.14, 0.16]]
+        NN-40-80:
+          arg-groups:
+            - {"n_neighbors": [40, 80], "diversify_epsilon": [0.0, 1.0], "pruning_degree_multiplier":[2.0, 2.5], "leaf_size":64}
+          query-args: [[0.0, 0.04, 0.08, 0.12, 0.16, 0.20, 0.24, 0.28, 0.32]]
     NGT-panng:
       docker-tag: ann-benchmarks-ngt
       module: ann_benchmarks.algorithms.panng_ngt
@@ -380,9 +385,16 @@ float:
       constructor: PyNNDescent
       base-args: ["@metric"]
       run-groups:
-        pynndescent:
-          args: [[5, 10, 20, 40, 80], [4, 8], [20]]
-          query-args: [[1.0, 1.5, 2.0, 4.0, 8.0]]
+        NN-10-20:
+          arg-groups:
+            - {"n_neighbors": [10, 20], "diversify_epsilon": [1.0],
+               "pruning_degree_multiplier":[1.0, 1.5, 2.0], "leaf_size":32}
+          query-args: [[0.0, 0.02, 0.04, 0.06, 0.08, 0.10, 0.12, 0.14, 0.16]]
+        NN-40-80:
+          arg-groups:
+            - {"n_neighbors": [40, 80], "diversify_epsilon": [0.0, 1.0],
+               "pruning_degree_multiplier":[2.0, 2.5], "leaf_size":64}
+          query-args: [[0.0, 0.04, 0.08, 0.12, 0.16, 0.20, 0.24, 0.28, 0.32]]
   angular:
     puffinn:
       docker-tag: ann-benchmarks-puffinn
@@ -469,9 +481,26 @@ float:
       constructor: PyNNDescent
       base-args: ["@metric"]
       run-groups:
-        pynndescent:
-          args: [[5, 10, 20, 40, 80, 160], [8], [40]]
-          query-args: [[1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0]]
+        NN-20:
+          arg-groups:
+            - {"n_neighbors": [20], "diversify_epsilon": [0.75, 1.0],
+               "pruning_degree_multiplier":[1.0, 1.5], leaf_size: 32}
+          query-args: [[0.0, 0.01, 0.02, 0.04, 0.08, 0.12, 0.16]]
+        NN-40:
+          arg-groups:
+            - {"n_neighbors": [40], "diversify_epsilon": [0.5, 1.0],
+               "pruning_degree_multiplier":[1.5, 2.0], leaf_size: 48}
+          query-args: [[0.0, 0.04, 0.08, 0.12, 0.16, 0.20, 0.24]]
+        NN-80:
+          arg-groups:
+            - {"n_neighbors": [80], "diversify_epsilon": [0.25, 1.0],
+               "pruning_degree_multiplier":[1.75, 2.25], leaf_size: 64}
+          query-args: [[0.0, 0.08, 0.12, 0.16, 0.20, 0.24, 0.28, 0.32]]
+        NN-120:
+          arg-groups:
+            - {"n_neighbors": [120], "diversify_epsilon": [0.0, 1.0],
+               "pruning_degree_multiplier":[2.0, 2.5], leaf_size: 80}
+          query-args: [[0.08, 0.16, 0.20, 0.24, 0.28, 0.32, 0.36]]
 bit:
   hamming:
     mih:
@@ -527,11 +556,28 @@ bit:
       docker-tag: ann-benchmarks-pynndescent
       module: ann_benchmarks.algorithms.pynndescent
       constructor: PyNNDescent
-      base-args: ["euclidean"]
+      base-args: ["@metric"]
       run-groups:
-        pynndescent:
-          args: [[20, 40, 80, 160, 250], [4], [40]]
-          query-args: [[1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0]]
+        NN-20:
+          arg-groups:
+            - {"n_neighbors": [20], "diversify_epsilon": [0.75, 1.0],
+               "pruning_degree_multiplier":[1.0, 1.5], leaf_size: 32}
+          query-args: [[0.0, 0.01, 0.02, 0.04, 0.08, 0.12, 0.16]]
+        NN-40:
+          arg-groups:
+            - {"n_neighbors": [40], "diversify_epsilon": [0.5, 1.0],
+               "pruning_degree_multiplier":[1.5, 2.0], leaf_size: 48}
+          query-args: [[0.0, 0.04, 0.08, 0.12, 0.16, 0.20, 0.24]]
+        NN-80:
+          arg-groups:
+            - {"n_neighbors": [80], "diversify_epsilon": [0.25, 1.0],
+               "pruning_degree_multiplier":[1.75, 2.25], leaf_size: 64}
+          query-args: [[0.0, 0.08, 0.12, 0.16, 0.20, 0.24, 0.28, 0.32]]
+        NN-120:
+          arg-groups:
+            - {"n_neighbors": [120], "diversify_epsilon": [0.0, 1.0],
+               "pruning_degree_multiplier":[2.0, 2.5], leaf_size: 80}
+          query-args: [[0.08, 0.16, 0.20, 0.24, 0.28, 0.32, 0.36]]
     annoy:
       docker-tag: ann-benchmarks-annoy
       module: ann_benchmarks.algorithms.annoy
@@ -583,3 +629,29 @@ bit:
               ['1bit_minhash'],
             ]
             query-args: [[0.1, 0.2, 0.5, 0.7, 0.9, 0.95, 0.99]]
+    pynndescent:
+      docker-tag: ann-benchmarks-pynndescent
+      module: ann_benchmarks.algorithms.pynndescent
+      constructor: PyNNDescent
+      base-args: ["@metric"]
+      run-groups:
+        NN-20:
+          arg-groups:
+            - {"n_neighbors": [20], "diversify_epsilon": [0.75, 1.0],
+               "pruning_degree_multiplier":[1.0, 1.5], leaf_size: 32}
+          query-args: [[0.0, 0.01, 0.02, 0.04, 0.08, 0.12, 0.16]]
+        NN-40:
+          arg-groups:
+            - {"n_neighbors": [40], "diversify_epsilon": [0.5, 1.0],
+               "pruning_degree_multiplier":[1.5, 2.0], leaf_size: 48}
+          query-args: [[0.0, 0.04, 0.08, 0.12, 0.16, 0.20, 0.24]]
+        NN-80:
+          arg-groups:
+            - {"n_neighbors": [80], "diversify_epsilon": [0.25, 1.0],
+               "pruning_degree_multiplier":[1.75, 2.25], leaf_size: 64}
+          query-args: [[0.0, 0.08, 0.12, 0.16, 0.20, 0.24, 0.28, 0.32]]
+        NN-120:
+          arg-groups:
+            - {"n_neighbors": [120], "diversify_epsilon": [0.0, 1.0],
+               "pruning_degree_multiplier":[2.0, 2.5], leaf_size: 80}
+          query-args: [[0.08, 0.16, 0.20, 0.24, 0.28, 0.32, 0.36]]

--- a/algos.yaml
+++ b/algos.yaml
@@ -268,11 +268,13 @@ float:
       run-groups:
         NN-10-20:
           arg-groups:
-            - {"n_neighbors": [10, 20], "diversify_epsilon": [1.0], "pruning_degree_multiplier":[1.0, 1.5, 2.0], "leaf_size":32}
+            - {"n_neighbors": [10, 20], "diversify_epsilon": [1.0],
+               "pruning_degree_multiplier":[1.5, 2.0], "leaf_size": 32}
           query-args: [[0.0, 0.02, 0.04, 0.06, 0.08, 0.10, 0.12, 0.14, 0.16]]
         NN-40-80:
           arg-groups:
-            - {"n_neighbors": [40, 80], "diversify_epsilon": [0.0, 1.0], "pruning_degree_multiplier":[2.0, 2.5], "leaf_size":64}
+            - {"n_neighbors": [40, 80], "diversify_epsilon": [0.0, 1.0],
+               "pruning_degree_multiplier":[2.0, 2.5], "leaf_size": 64}
           query-args: [[0.0, 0.04, 0.08, 0.12, 0.16, 0.20, 0.24, 0.28, 0.32]]
     NGT-panng:
       docker-tag: ann-benchmarks-ngt
@@ -388,12 +390,12 @@ float:
         NN-10-20:
           arg-groups:
             - {"n_neighbors": [10, 20], "diversify_epsilon": [1.0],
-               "pruning_degree_multiplier":[1.0, 1.5, 2.0], "leaf_size":32}
+               "pruning_degree_multiplier":[1.5, 2.0], "leaf_size": 32}
           query-args: [[0.0, 0.02, 0.04, 0.06, 0.08, 0.10, 0.12, 0.14, 0.16]]
         NN-40-80:
           arg-groups:
             - {"n_neighbors": [40, 80], "diversify_epsilon": [0.0, 1.0],
-               "pruning_degree_multiplier":[2.0, 2.5], "leaf_size":64}
+               "pruning_degree_multiplier":[2.0, 2.5], "leaf_size": 64}
           query-args: [[0.0, 0.04, 0.08, 0.12, 0.16, 0.20, 0.24, 0.28, 0.32]]
   angular:
     puffinn:

--- a/ann_benchmarks/algorithms/pynndescent.py
+++ b/ann_benchmarks/algorithms/pynndescent.py
@@ -1,14 +1,37 @@
 from __future__ import absolute_import
 import pynndescent
 from ann_benchmarks.algorithms.base import BaseANN
+import numpy as np
 
 
 class PyNNDescent(BaseANN):
-    def __init__(self, metric, n_neighbors=10, n_trees=8, leaf_size=20):
-        self._n_neighbors = int(n_neighbors)
-        self._n_trees = int(n_trees)
-        self._leaf_size = int(leaf_size)
-        self._queue_size = None
+
+    def __init__(self, metric, index_param_dict, n_search_trees=1, n_jobs=1):
+        if "n_neighbors" in index_param_dict:
+            self._n_neighbors = int(index_param_dict["n_neighbors"])
+        else:
+            self._n_neighbors = 10
+
+        if "pruning_degree_multiplier" in index_param_dict:
+            self._pruning_degree_multiplier = float(
+                index_param_dict["pruning_degree_multiplier"])
+        else:
+            self._pruning_degree_multiplier = 1.5
+
+        if "diversify_epsilon" in index_param_dict:
+            self._diversify_epsilon = float(index_param_dict["diversify_epsilon"])
+        else:
+            self._diversify_epsilon = 1.0
+
+        if "leaf_size" in index_param_dict:
+            self._leaf_size = int(index_param_dict["leaf_size"])
+        else:
+            leaf_size = 32
+
+        self._n_search_trees = int(n_search_trees)
+        self._n_jobs = int(n_jobs)
+
+        self._n_search_trees = int(n_search_trees)
         self._pynnd_metric = {'angular': 'cosine',
                               'euclidean': 'euclidean',
                               'hamming': 'hamming',
@@ -17,21 +40,28 @@ class PyNNDescent(BaseANN):
     def fit(self, X):
         self._index = pynndescent.NNDescent(X,
                                             n_neighbors=self._n_neighbors,
-                                            n_trees=self._n_trees,
+                                            metric=self._pynnd_metric,
+                                            low_memory=True,
                                             leaf_size=self._leaf_size,
-                                            metric=self._pynnd_metric)
+                                            pruning_degree_multiplier=self._pruning_degree_multiplier,
+                                            diversify_epsilon=self._diversify_epsilon,
+                                            n_search_trees=self._n_search_trees,
+                                            n_jobs=self._n_jobs)
+        self._index._init_search_graph()
 
-    def set_query_arguments(self, queue_size):
-        self._queue_size = float(queue_size)
+    def set_query_arguments(self, epsilon=0.1):
+        self._epsilon = float(epsilon)
 
     def query(self, v, n):
         ind, dist = self._index.query(
             v.reshape(1, -1).astype('float32'), k=n,
-            queue_size=self._queue_size)
+            epsilon=self._epsilon)
         return ind[0]
 
     def __str__(self):
-        str_template = ('PyNNDescent(n_neighbors=%d, n_trees=%d, leaf_size=%d'
-                        ', queue_size=%.2f)')
-        return str_template % (self._n_neighbors, self._n_trees,
-                               self._leaf_size, self._queue_size)
+        str_template = (
+            'PyNNDescent(n_neighbors=%d, pruning_mult=%.1f, diversify_epsilon=%.2f, epsilon=%.3f, leaf_size=%03d)')
+        return str_template % (
+        self._n_neighbors, self._pruning_degree_multiplier, self._diversify_epsilon,
+        self._epsilon, self._leaf_size)
+

--- a/install/Dockerfile.pynndescent
+++ b/install/Dockerfile.pynndescent
@@ -1,6 +1,5 @@
 FROM ann-benchmarks
 
 RUN pip3 install numba scikit-learn
-RUN git clone https://github.com/lmcinnes/pynndescent
-RUN cd pynndescent && python3 setup.py install
+RUN pip3 install pynndescent
 RUN python3 -c 'import pynndescent'


### PR DESCRIPTION
It seems like pynndescent was broken (or otherwise drastically underperforming) in the last round. I've updated pynndescent, and pushed a new version to PyPI. This PR should update ann-benchmarks to use the new version (with it's changed parameters), and now only pull from PyPI (rather than master on the github repository) so it should be more stable in future.