### PR TITLE
Support for jaccard with pynndescent

### DIFF
--- a/ann_benchmarks/algorithms/pynndescent.py
+++ b/ann_benchmarks/algorithms/pynndescent.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 import pynndescent
 from ann_benchmarks.algorithms.base import BaseANN
 import numpy as np
+import scipy.sparse
 
 
 class PyNNDescent(BaseANN):
@@ -37,7 +38,32 @@ class PyNNDescent(BaseANN):
                               'hamming': 'hamming',
                               'jaccard': 'jaccard'}[metric]
 
+    def _sparse_convert_for_fit(self, X):
+        lil_data = []
+        self._n_cols = 1
+        self._n_rows = len(X)
+        for i in range(self._n_rows):
+            lil_data.append([1] * len(X[i]))
+            if max(X[i]) + 1 > self._n_cols:
+                self._n_cols = max(X[i]) + 1
+
+        result = scipy.sparse.lil_matriux((self._n_rows, self._n_cols), dtype=np.int)
+        result.rows = np.array(X)
+        result.data = np.array(lil_data)
+        return result.tocsr()
+
+    def _sparse_convert_for_query(self, v):
+        result = scipy.sparse.csr_matrix((1, self._n_cols), dtype=np.int)
+        result.indptr = np.array([0, len(v)])
+        result.indices = np.array(v).astype(np.int32)
+        result.data = np.ones(len(v), dtype=np.int)
+        return result
+
     def fit(self, X):
+        if self._pynnd_metric == 'jaccard':
+            # Convert to sparse matrix format
+            X = self._sparse_convert_for_fit(X)
+
         self._index = pynndescent.NNDescent(X,
                                             n_neighbors=self._n_neighbors,
                                             metric=self._pynnd_metric,
@@ -53,9 +79,14 @@ class PyNNDescent(BaseANN):
         self._epsilon = float(epsilon)
 
     def query(self, v, n):
-        ind, dist = self._index.query(
-            v.reshape(1, -1).astype('float32'), k=n,
-            epsilon=self._epsilon)
+        if self._pynnd_metric == 'jaccard':
+            # convert index array to sparse matrix format and query
+            v = self._sparse_convert_for_query(v)
+            ind, dist = self._index.query(v, k=n, epsilon=self._epsilon)
+        else:
+            ind, dist = self._index.query(
+                v.reshape(1, -1).astype('float32'), k=n,
+                epsilon=self._epsilon)
         return ind[0]
 
     def __str__(self):

--- a/install/Dockerfile.pynndescent
+++ b/install/Dockerfile.pynndescent
@@ -1,5 +1,5 @@
 FROM ann-benchmarks
 
-RUN pip3 install numba scikit-learn
+RUN pip3 install 'numba==0.46' 'llvmlite==0.30' scikit-learn
 RUN pip3 install pynndescent
 RUN python3 -c 'import pynndescent'


### PR DESCRIPTION
Pynndescent supports jaccard distances on datasets like kosarak via the scipy sparse matrix format. This updates the pynndescent algorithm wrapper to convert data into the requisite sparse format when using jaccard. I also pinned the numba and llvmlite versions as the current release combinations have some issues that break pynndescent.