### PR TITLE
Add an dataset based on 'deep image descriptors'.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ We have a number of precomputed data sets for this. All data sets are pre-split 
 
 | Dataset                                                           | Dimensions | Train size | Test size | Neighbors | Distance  | Download                                                                   |
 | ----------------------------------------------------------------- | ---------: | ---------: | --------: | --------: | --------- | -------------------------------------------------------------------------- |
+| [DEEP1B](http://sites.skoltech.ru/compvision/noimi/)              |         96 | 10,000,000 |    10,000 |       100 | Angular   | [HDF5](http://ann-benchmarks.com/deep-image-96-angular.hdf5) (3.6GB)
 | [Fashion-MNIST](https://github.com/zalandoresearch/fashion-mnist) |        784 |     60,000 |    10,000 |       100 | Euclidean | [HDF5](http://ann-benchmarks.com/fashion-mnist-784-euclidean.hdf5) (217MB) |
 | [GIST](http://corpus-texmex.irisa.fr/)                            |        960 |  1,000,000 |     1,000 |       100 | Euclidean | [HDF5](http://ann-benchmarks.com/gist-960-euclidean.hdf5) (3.6GB)          |
 | [GloVe](http://nlp.stanford.edu/projects/glove/)                  |         25 |  1,183,514 |    10,000 |       100 | Angular   | [HDF5](http://ann-benchmarks.com/glove-25-angular.hdf5) (121MB)            |

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ We have a number of precomputed data sets for this. All data sets are pre-split 
 
 | Dataset                                                           | Dimensions | Train size | Test size | Neighbors | Distance  | Download                                                                   |
 | ----------------------------------------------------------------- | ---------: | ---------: | --------: | --------: | --------- | -------------------------------------------------------------------------- |
-| [DEEP1B](http://sites.skoltech.ru/compvision/noimi/)              |         96 | 10,000,000 |    10,000 |       100 | Angular   | [HDF5](http://ann-benchmarks.com/deep-image-96-angular.hdf5) (3.6GB)
+| [DEEP1B](http://sites.skoltech.ru/compvision/noimi/)              |         96 |  9,990,000 |    10,000 |       100 | Angular   | [HDF5](http://ann-benchmarks.com/deep-image-96-angular.hdf5) (3.6GB)
 | [Fashion-MNIST](https://github.com/zalandoresearch/fashion-mnist) |        784 |     60,000 |    10,000 |       100 | Euclidean | [HDF5](http://ann-benchmarks.com/fashion-mnist-784-euclidean.hdf5) (217MB) |
 | [GIST](http://corpus-texmex.irisa.fr/)                            |        960 |  1,000,000 |     1,000 |       100 | Euclidean | [HDF5](http://ann-benchmarks.com/gist-960-euclidean.hdf5) (3.6GB)          |
 | [GloVe](http://nlp.stanford.edu/projects/glove/)                  |         25 |  1,183,514 |    10,000 |       100 | Angular   | [HDF5](http://ann-benchmarks.com/glove-25-angular.hdf5) (121MB)            |

--- a/ann_benchmarks/datasets.py
+++ b/ann_benchmarks/datasets.py
@@ -211,9 +211,9 @@ def deep_image(out_fn):
     # length as an integer, then writing its components as floats.
     fv = numpy.fromfile(filename, dtype=numpy.float32)
     dim = fv.view(numpy.int32)[0]
-    X = fv.reshape(-1, dim + 1)[:, 1:]
+    fv = fv.reshape(-1, dim + 1)[:, 1:]
 
-    X_train, X_test = train_test_split(X)
+    X_train, X_test = train_test_split(fv)
     write_output(X_train, X_test, out_fn, 'angular')
 
 def transform_bag_of_words(filename, n_dimensions, out_fn):

--- a/ann_benchmarks/datasets.py
+++ b/ann_benchmarks/datasets.py
@@ -4,7 +4,7 @@ import os
 import random
 import sys
 
-from  urllib.request import urlopen
+from urllib.request import urlopen
 try:
     from urllib import urlretrieve
 except ImportError:
@@ -198,12 +198,9 @@ def fashion_mnist(out_fn):
 # from http://sites.skoltech.ru/compvision/noimi/. The download logic is adapted
 # from the script https://github.com/arbabenko/GNOIMI/blob/master/downloadDeep1B.py.
 def deep_image(out_fn):
-    train_size = 10 * 1000 * 1000
-    test_size = 10000
-
     yadisk_key = 'https://yadi.sk/d/11eDCm7Dsn9GA'
     response = urlopen('https://cloud-api.yandex.net/v1/disk/public/resources/download?public_key=' \
-        + yadisk_key + '&path=/base/base_00')
+        + yadisk_key + '&path=/deep10M.fvecs')
     response_body = response.read().decode("utf-8")
 
     dataset_url = response_body.split(',')[0][9:-1]
@@ -214,12 +211,9 @@ def deep_image(out_fn):
     # length as an integer, then writing its components as floats.
     fv = numpy.fromfile(filename, dtype=numpy.float32)
     dim = fv.view(numpy.int32)[0]
-
-    limit = (dim + 1) * (train_size + test_size)
-    fv = fv[0:limit]
     X = fv.reshape(-1, dim + 1)[:, 1:]
 
-    X_train, X_test = train_test_split(X, test_size=test_size)
+    X_train, X_test = train_test_split(X)
     write_output(X_train, X_test, out_fn, 'angular')
 
 def transform_bag_of_words(filename, n_dimensions, out_fn):

--- a/ann_benchmarks/datasets.py
+++ b/ann_benchmarks/datasets.py
@@ -199,7 +199,7 @@ def fashion_mnist(out_fn):
 # from the script https://github.com/arbabenko/GNOIMI/blob/master/downloadDeep1B.py.
 def deep_image(out_fn):
     train_size = 10 * 1000 * 1000
-    test_size = 1000
+    test_size = 10000
 
     yadisk_key = 'https://yadi.sk/d/11eDCm7Dsn9GA'
     response = urlopen('https://cloud-api.yandex.net/v1/disk/public/resources/download?public_key=' \
@@ -217,7 +217,7 @@ def deep_image(out_fn):
 
     limit = (dim + 1) * (train_size + test_size)
     fv = fv[0:limit]
-    X_train = fv.reshape(-1, dim + 1)[:, 1:]
+    X = fv.reshape(-1, dim + 1)[:, 1:]
 
     X_train, X_test = train_test_split(X, test_size=test_size)
     write_output(X_train, X_test, out_fn, 'angular')


### PR DESCRIPTION
This commit adds an image similarity dataset based on the data from 'Efficient
Indexing of Billion-Scale datasets of deep descriptors'. The data is composed of
images from the web that have been run through a 'deep descriptor network' to
produce vectors. The vectors were then reduced to 96 dimensions through PCA and
finally L2-normalized. We use a 10 million vector sample of the full dataset.

The original dataset can be downloaded from
http://sites.skoltech.ru/compvision/noimi/. The 10 million vectors are taken from
the file deep10M.fvecs. I emailed the authors of the dataset (with @erikbern in CC)
and they're okay with us committing a sample of the dataset.

Closes #143.