### PR TITLE
Elastiknn for Euclidean datasets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ env:
   - LIBRARY=mih DATASET=random-xs-16-hamming
   - LIBRARY=datasketch DATASET=random-s-jaccard
   - LIBRARY=scann DATASET=random-xs-20-angular
+  - LIBRARY=elastiknn DATASET=random-xs-20-angular
 
 before_install:
   - pip install -r requirements.txt

--- a/algos.yaml
+++ b/algos.yaml
@@ -218,7 +218,7 @@ float:
         M-96:
           arg-groups:
             - {"M": 96,  "efConstruction": 500}
-          query-args: [[10, 20, 40, 80, 120, 200, 400, 600, 800]] 
+          query-args: [[10, 20, 40, 80, 120, 200, 400, 600, 800]]
 
     bruteforce:
       disabled: true
@@ -338,6 +338,14 @@ float:
           args: ["@count"]
           query-args: [[0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.85, 0.9,
                         0.925, 0.95, 0.97, 0.98, 0.99, 0.995]]
+    elastiknn-exact:
+      docker-tag: ann-benchmarks-elastiknn
+      module: ann_benchmarks.algorithms.elastiknn
+      constructor: Exact
+      base-args: [ "@metric", "@dimension" ]
+      run-groups:
+        exact:
+          args: []
   euclidean:
     kgraph:
       docker-tag: ann-benchmarks-kgraph
@@ -431,6 +439,21 @@ float:
             - {"n_neighbors": [40, 80], "diversify_epsilon": [0.0, 1.0],
                "pruning_degree_multiplier":[2.0, 2.5], "leaf_size": 64}
           query-args: [[0.0, 0.04, 0.08, 0.12, 0.16, 0.20, 0.24, 0.28, 0.32]]
+    elastiknn-l2lsh:
+      docker-tag: ann-benchmarks-elastiknn
+      module: ann_benchmarks.algorithms.elastiknn
+      constructor: L2Lsh
+      base-args: []
+      run-groups:
+        elastiknn-lsh:
+          args:
+            - [50, 75]
+            - [3, 4]
+            - [1, 3, 7]
+          query-args:
+            - [1000, 10000]
+            - [0, 3, 6, 9]
+
   angular:
     puffinn:
       docker-tag: ann-benchmarks-puffinn

--- a/ann_benchmarks/algorithms/elastiknn.py
+++ b/ann_benchmarks/algorithms/elastiknn.py
@@ -1,0 +1,97 @@
+"""
+ann-benchmarks interfaces for elastiknn: https://github.com/alexklibisz/elastiknn
+Uses the elastiknn python client
+To install a local copy of the client, run `pip install --upgrade -e /path/to/elastiknn/client-python/`
+To monitor the Elasticsearch JVM using Visualvm, add `ports={ "8097": 8097 }` to the `containers.run` call in runner.py.
+"""
+from urllib.error import URLError
+
+import numpy as np
+from elastiknn.api import Vec
+from elastiknn.models import ElastiknnModel
+from elastiknn.utils import dealias_metric
+
+from ann_benchmarks.algorithms.base import BaseANN
+
+from urllib.request import Request, urlopen
+from time import sleep
+
+
+def es_wait():
+    print("Waiting for elasticsearch health endpoint...")
+    req = Request("http://localhost:9200/_cluster/health?wait_for_status=yellow&timeout=1s")
+    for i in range(30):
+        try:
+            res = urlopen(req)
+            if res.getcode() == 200:
+                print("Elasticsearch is ready")
+                return
+        except URLError:
+            pass
+        sleep(1)
+    raise RuntimeError("Failed to connec to local elasticsearch")
+
+
+class Exact(BaseANN):
+
+    def __init__(self, metric: str, dimension: int):
+        self.name = f"eknn-exact-metric={metric}_dimension={dimension}"
+        self.metric = metric
+        self.dimension = dimension
+        self.model = ElastiknnModel("exact", dealias_metric(metric))
+        self.batch_res = None
+        es_wait()
+
+    def _handle_sparse(self, X):
+        # convert list of lists of indices to sparse vectors.
+        return [Vec.SparseBool(x, self.dimension) for x in X]
+
+    def fit(self, X):
+        if self.metric in {'jaccard', 'hamming'}:
+            return self.model.fit(self._handle_sparse(X), shards=1)[0]
+        else:
+            return self.model.fit(X, shards=1)
+
+    def query(self, q, n):
+        if self.metric in {'jaccard', 'hamming'}:
+            return self.model.kneighbors(self._handle_sparse([q]), n)[0]
+        else:
+            return self.model.kneighbors(np.expand_dims(q, 0), n)[0]
+
+    def batch_query(self, X, n):
+        if self.metric in {'jaccard', 'hamming'}:
+            self.batch_res = self.model.kneighbors(self._handle_sparse(X), n)
+        else:
+            self.batch_res = self.model.kneighbors(X, n)
+
+    def get_batch_results(self):
+        return self.batch_res
+
+
+class L2Lsh(BaseANN):
+
+    def __init__(self, L: int, k: int, w: int):
+        self.name_prefix = f"eknn-l2lsh-L={L}-k={k}-w={w}"
+        self.name = None  # set based on query args.
+        self.model = ElastiknnModel("lsh", "l2", mapping_params=dict(L=L, k=k, w=w))
+        self.X_max = 1.0
+        self.query_params = dict()
+        self.batch_res = None
+        es_wait()
+
+    def fit(self, X):
+        self.X_max = X.max()
+        return self.model.fit(X / self.X_max, shards=1)
+
+    def set_query_arguments(self, candidates: int, probes: int):
+        self.name = f"{self.name_prefix}_candidates={candidates}_probes={probes}"
+        self.query_params = dict(candidates=candidates, probes=probes)
+
+    def query(self, q, n):
+        return self.model.kneighbors(np.expand_dims(q, 0) / self.X_max, n, query_params=self.query_params)[0]
+
+    def batch_query(self, X, n):
+        self.batch_res = self.model.kneighbors(X, n)
+
+    def get_batch_results(self):
+        return self.batch_res

--- a/ann_benchmarks/runner.py
+++ b/ann_benchmarks/runner.py
@@ -248,9 +248,9 @@ def run_docker(definition, dataset, count, runs, timeout, batch, cpu_limit,
         # Exit if exit code
         if exit_code not in [0, None]:
             print(colors.color(container.logs().decode(), fg='red'))
-            print('Child process raised exception %d' % exit_code)
+            print('Child process for container %s raised exception %d' % (container.short_id, exit_code))
     except:
-        print('Container.wait failed with exception')
+        print('Container.wait for container %s failed with exception' % container.short_id)
         traceback.print_exc()
     finally:
         container.remove(force=True)

--- a/install/Dockerfile.elastiknn
+++ b/install/Dockerfile.elastiknn
@@ -13,11 +13,11 @@ RUN wget --quiet https://artifacts.elastic.co/downloads/elasticsearch/elasticsea
 ENV PATH="/usr/share/elasticsearch/bin:$PATH"
 
 # Install python client.
-RUN python3 -m pip install --upgrade elastiknn-client==0.1.0rc34
+RUN python3 -m pip install --upgrade elastiknn-client==0.1.0rc35
 
 # Install plugin.
 RUN elasticsearch-plugin install --batch \
-    https://github.com/alexklibisz/elastiknn/releases/download/0.1.0-PRE34/elastiknn-0.1.0-PRE34_es7.6.2.zip
+    https://github.com/alexklibisz/elastiknn/releases/download/0.1.0-PRE35/elastiknn-0.1.0-PRE35_es7.6.2.zip
 
 # Configure elasticsearch and JVM for single-node, single-core.
 RUN cp /etc/elasticsearch/jvm.options /etc/elasticsearch/jvm.options.bak

--- a/install/Dockerfile.elastiknn
+++ b/install/Dockerfile.elastiknn
@@ -1,0 +1,64 @@
+FROM ann-benchmarks
+
+WORKDIR /home/app
+
+# Install elasticsearch.
+ENV DEBIAN_FRONTEND noninteractive
+RUN apt install -y wget curl htop
+RUN wget --quiet https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-oss-7.6.2-amd64.deb \
+    && dpkg -i elasticsearch-oss-7.6.2-amd64.deb \
+    && rm elasticsearch-oss-7.6.2-amd64.deb
+
+# Put ES on the path.
+ENV PATH="/usr/share/elasticsearch/bin:$PATH"
+
+# Install python client.
+RUN python3 -m pip install --upgrade elastiknn-client==0.1.0rc34
+
+# Install plugin.
+RUN elasticsearch-plugin install --batch \
+    https://github.com/alexklibisz/elastiknn/releases/download/0.1.0-PRE34/elastiknn-0.1.0-PRE34_es7.6.2.zip
+
+# Configure elasticsearch and JVM for single-node, single-core.
+RUN cp /etc/elasticsearch/jvm.options /etc/elasticsearch/jvm.options.bak
+RUN cp /etc/elasticsearch/elasticsearch.yml /etc/elasticsearch/elasticsearch.yml.bak
+
+RUN echo '\
+discovery.type: single-node\n\
+network.host: 0.0.0.0\n\
+node.master: true\n\
+node.data: true\n\
+node.processors: 1\n\
+thread_pool.write.size: 1\n\
+thread_pool.search.size: 1\n\
+thread_pool.search.queue_size: 1\n\
+path.data: /var/lib/elasticsearch\n\
+path.logs: /var/log/elasticsearch\n\
+' > /etc/elasticsearch/elasticsearch.yml
+
+RUN echo '\
+-Xms3G\n\
+-Xmx3G\n\
+-XX:+UseG1GC\n\
+-XX:G1ReservePercent=25\n\
+-XX:InitiatingHeapOccupancyPercent=30\n\
+-XX:+HeapDumpOnOutOfMemoryError\n\
+-XX:HeapDumpPath=/var/lib/elasticsearch\n\
+-XX:ErrorFile=/var/log/elasticsearch/hs_err_pid%p.log\n\
+-Xlog:gc*,gc+age=trace,safepoint:file=/var/log/elasticsearch/gc.log:utctime,pid,tags:filecount=32,filesize=64m\n\
+-Dcom.sun.management.jmxremote.ssl=false\n\
+-Dcom.sun.management.jmxremote.authenticate=false\n\
+-Dcom.sun.management.jmxremote.local.only=false\n\
+-Dcom.sun.management.jmxremote.port=8097\n\
+-Dcom.sun.management.jmxremote.rmi.port=8097\n\
+-Djava.rmi.server.hostname=localhost' > /etc/elasticsearch/jvm.options
+
+# JMX port. Need to also map the port when running.
+EXPOSE 8097
+
+# Make sure you can start the service.
+RUN service elasticsearch start && service elasticsearch stop
+
+# Custom entrypoint that also starts the Elasticsearch server.\
+RUN echo 'service elasticsearch start && python3 -u run_algorithm.py "$@"' > entrypoint.sh
+ENTRYPOINT ["/bin/bash", "/home/app/entrypoint.sh"]


### PR DESCRIPTION
First pass at setting up Elastiknn. 

For now I'm only including it for Euclidean datasets. I'll work on angular, jaccard and hamming over the next couple weeks.

I tested this out on a C5.4xLarge and it seems to work reliably with `--runs 5 --parallelism 3 --count 100`. I'll run it again over night tonight to be extra sure it runs to completion. It is quite a bit slower than the existing algos, for pretty obvious reasons (Java, making HTTP requests, writing to disk, etc.). The numbers I was seeing in my ann-benchmarks runs are pretty much the same as I saw in my own benchmarking, [which is reported here](http://elastiknn.klibisz.com/performance/). Fashion mnist peaks at about 200 q/sec and sift at about 100 q/sec.

I made a slight modification to the runner, so that when a container fails, it prints the short ID of the container. This was helpful in debugging, but I'm also happy to revert it.

LMK if there's anything I'm missing in the integration and I'll fix it ASAP. The only thing I'm fuzzy on: how does travis know to build the image? I was manually running `docker build` commands locally.