### PR TITLE
Elasticsearch with dense_vector field type and script_score query

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,10 @@ install/*.yaml
 install/lib-*/
 data/*
 *.class
+
+results/*
+!results/*.png
+
+venv
+
+.idea

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ env:
   - LIBRARY=mih DATASET=random-xs-16-hamming
   - LIBRARY=datasketch DATASET=random-s-jaccard
   - LIBRARY=scann DATASET=random-xs-20-angular
+  - LIBRARY=elasticsearch DATASET=random-xs-20-angular
 
 before_install:
   - pip install -r requirements.txt

--- a/algos.yaml
+++ b/algos.yaml
@@ -338,6 +338,7 @@ float:
           args: ["@count"]
           query-args: [[0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.85, 0.9,
                         0.925, 0.95, 0.97, 0.98, 0.99, 0.995]]
+
   euclidean:
     kgraph:
       docker-tag: ann-benchmarks-kgraph
@@ -431,6 +432,15 @@ float:
             - {"n_neighbors": [40, 80], "diversify_epsilon": [0.0, 1.0],
                "pruning_degree_multiplier":[2.0, 2.5], "leaf_size": 64}
           query-args: [[0.0, 0.04, 0.08, 0.12, 0.16, 0.20, 0.24, 0.28, 0.32]]
+    elasticsearch:
+      docker-tag: ann-benchmarks-elasticsearch
+      module: ann_benchmarks.algorithms.elasticsearch
+      constructor: ElasticsearchScriptScoreQuery
+      base-args: [ "@metric", "@dimension" ]
+      run-groups:
+        empty:
+          args: []
+
   angular:
     puffinn:
       docker-tag: ann-benchmarks-puffinn
@@ -551,6 +561,15 @@ float:
         scann3:
           args: [[1000], [.2], [1]]
           query-args: [[[9, 25], [11, 35], [12, 35], [13, 35], [14, 40], [15, 40], [16, 40], [17, 45], [20, 45], [20, 55], [25, 55], [25, 70], [30, 70], [40, 90], [50, 100], [60, 120], [70, 140]]]
+    elasticsearch:
+      docker-tag: ann-benchmarks-elasticsearch
+      module: ann_benchmarks.algorithms.elasticsearch
+      constructor: ElasticsearchScriptScoreQuery
+      base-args: [ "@metric", "@dimension" ]
+      run-groups:
+        empty:
+          args: []
+
 bit:
   hamming:
     mih:

--- a/ann_benchmarks/algorithms/elasticsearch.py
+++ b/ann_benchmarks/algorithms/elasticsearch.py
@@ -1,0 +1,102 @@
+"""
+ann-benchmarks interfaces for Elasticsearch.
+Note that this requires X-Pack, which is not included in the OSS version of Elasticsearch.
+"""
+import logging
+from time import sleep
+from urllib.error import URLError
+from urllib.request import Request, urlopen
+
+from elasticsearch import Elasticsearch
+from elasticsearch.helpers import bulk
+
+from ann_benchmarks.algorithms.base import BaseANN
+
+# Configure the elasticsearch logger.
+# By default, it writes an INFO statement for every request.
+logging.getLogger("elasticsearch").setLevel(logging.WARN)
+
+# Uncomment these lines if you want to see timing for every HTTP request and its duration.
+# logging.basicConfig(level=logging.INFO)
+# logging.getLogger("elasticsearch").setLevel(logging.INFO)
+
+def es_wait():
+    print("Waiting for elasticsearch health endpoint...")
+    req = Request("http://localhost:9200/_cluster/health?wait_for_status=yellow&timeout=1s")
+    for i in range(30):
+        try:
+            res = urlopen(req)
+            if res.getcode() == 200:
+                print("Elasticsearch is ready")
+                return
+        except URLError:
+            pass
+        sleep(1)
+    raise RuntimeError("Failed to connect to local elasticsearch")
+
+
+class ElasticsearchScriptScoreQuery(BaseANN):
+    """
+    KNN using the Elasticsearch dense_vector datatype and script score functions.
+    - Dense vector field type: https://www.elastic.co/guide/en/elasticsearch/reference/master/dense-vector.html
+    - Dense vector queries: https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-script-score-query.html
+    """
+
+    def __init__(self, metric: str, dimension: int):
+        self.name = f"elasticsearch-script-score-query_metric={metric}_dimension={dimension}"
+        self.metric = metric
+        self.dimension = dimension
+        self.index = f"es-ssq-{metric}-{dimension}"
+        self.es = Elasticsearch(["http://localhost:9200"])
+        self.batch_res = []
+        if self.metric == "euclidean":
+            self.script = "1 / (1 + l2norm(params.query_vec, \"vec\"))"
+        elif self.metric == "angular":
+            self.script = "1.0 + cosineSimilarity(params.query_vec, \"vec\")"
+        else:
+            raise NotImplementedError(f"Not implemented for metric {self.metric}")
+        es_wait()
+
+    def fit(self, X):
+        body = dict(settings=dict(number_of_shards=1, number_of_replicas=0))
+        mapping = dict(
+            properties=dict(
+                id=dict(type="keyword", store=True),
+                vec=dict(type="dense_vector", dims=self.dimension)
+            )
+        )
+        self.es.indices.create(self.index, body=body)
+        self.es.indices.put_mapping(mapping, self.index)
+
+        def gen():
+            for i, vec in enumerate(X):
+                yield { "_op_type": "index", "_index": self.index, "vec": vec.tolist(), 'id': str(i + 1) }
+
+        (_, errors) = bulk(self.es, gen(), chunk_size=500, max_retries=9)
+        assert len(errors) == 0, errors
+
+        self.es.indices.refresh(self.index)
+        self.es.indices.forcemerge(self.index, max_num_segments=1)
+
+    def query(self, q, n):
+        body = dict(
+            query=dict(
+                script_score=dict(
+                    query=dict(match_all=dict()),
+                    script=dict(
+                        source=self.script,
+                        params=dict(query_vec=q.tolist())
+                    )
+                )
+            )
+        )
+        res = self.es.search(index=self.index, body=body, size=n, _source=False, docvalue_fields=['id'],
+                             stored_fields="_none_", filter_path=["hits.hits.fields.id"])
+        return [int(h['fields']['id'][0]) - 1 for h in res['hits']['hits']]
+
+    def batch_query(self, X, n):
+        self.batch_res = [self.query(q, n) for q in X]
+
+    def get_batch_results(self):
+        return self.batch_res
+

--- a/install/Dockerfile.elasticsearch
+++ b/install/Dockerfile.elasticsearch
@@ -9,16 +9,10 @@ RUN wget --quiet https://artifacts.elastic.co/downloads/elasticsearch/elasticsea
     && dpkg -i elasticsearch-7.9.2-amd64.deb \
     && rm elasticsearch-7.9.2-amd64.deb
 
-# Put ES on the path.
-ENV PATH="/usr/share/elasticsearch/bin:$PATH"
-
 # Install python client.
 RUN python3 -m pip install --upgrade elasticsearch==7.9.1
 
 # Configure elasticsearch and JVM for single-node, single-core.
-RUN cp /etc/elasticsearch/jvm.options /etc/elasticsearch/jvm.options.bak
-RUN cp /etc/elasticsearch/elasticsearch.yml /etc/elasticsearch/elasticsearch.yml.bak
-
 RUN echo '\
 discovery.type: single-node\n\
 network.host: 0.0.0.0\n\
@@ -41,8 +35,7 @@ RUN echo '\
 -XX:+HeapDumpOnOutOfMemoryError\n\
 -XX:HeapDumpPath=/var/lib/elasticsearch\n\
 -XX:ErrorFile=/var/log/elasticsearch/hs_err_pid%p.log\n\
--Xlog:gc*,gc+age=trace,safepoint:file=/var/log/elasticsearch/gc.log:utctime,pid,tags:filecount=32,filesize=64m\n\
--Djava.rmi.server.hostname=localhost' > /etc/elasticsearch/jvm.options
+-Xlog:gc*,gc+age=trace,safepoint:file=/var/log/elasticsearch/gc.log:utctime,pid,tags:filecount=32,filesize=64m' > /etc/elasticsearch/jvm.options
 
 # Make sure you can start the service.
 RUN service elasticsearch start && service elasticsearch stop

--- a/install/Dockerfile.elasticsearch
+++ b/install/Dockerfile.elasticsearch
@@ -1,0 +1,52 @@
+FROM ann-benchmarks
+
+WORKDIR /home/app
+
+# Install elasticsearch.
+ENV DEBIAN_FRONTEND noninteractive
+RUN apt install -y wget curl htop
+RUN wget --quiet https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.9.2-amd64.deb \
+    && dpkg -i elasticsearch-7.9.2-amd64.deb \
+    && rm elasticsearch-7.9.2-amd64.deb
+
+# Put ES on the path.
+ENV PATH="/usr/share/elasticsearch/bin:$PATH"
+
+# Install python client.
+RUN python3 -m pip install --upgrade elasticsearch==7.9.1
+
+# Configure elasticsearch and JVM for single-node, single-core.
+RUN cp /etc/elasticsearch/jvm.options /etc/elasticsearch/jvm.options.bak
+RUN cp /etc/elasticsearch/elasticsearch.yml /etc/elasticsearch/elasticsearch.yml.bak
+
+RUN echo '\
+discovery.type: single-node\n\
+network.host: 0.0.0.0\n\
+node.master: true\n\
+node.data: true\n\
+node.processors: 1\n\
+thread_pool.write.size: 1\n\
+thread_pool.search.size: 1\n\
+thread_pool.search.queue_size: 1\n\
+path.data: /var/lib/elasticsearch\n\
+path.logs: /var/log/elasticsearch\n\
+' > /etc/elasticsearch/elasticsearch.yml
+
+RUN echo '\
+-Xms3G\n\
+-Xmx3G\n\
+-XX:+UseG1GC\n\
+-XX:G1ReservePercent=25\n\
+-XX:InitiatingHeapOccupancyPercent=30\n\
+-XX:+HeapDumpOnOutOfMemoryError\n\
+-XX:HeapDumpPath=/var/lib/elasticsearch\n\
+-XX:ErrorFile=/var/log/elasticsearch/hs_err_pid%p.log\n\
+-Xlog:gc*,gc+age=trace,safepoint:file=/var/log/elasticsearch/gc.log:utctime,pid,tags:filecount=32,filesize=64m\n\
+-Djava.rmi.server.hostname=localhost' > /etc/elasticsearch/jvm.options
+
+# Make sure you can start the service.
+RUN service elasticsearch start && service elasticsearch stop
+
+# Custom entrypoint that also starts the Elasticsearch server.
+RUN echo 'service elasticsearch start && python3 -u run_algorithm.py "$@"' > entrypoint.sh
+ENTRYPOINT ["/bin/bash", "/home/app/entrypoint.sh"]


### PR DESCRIPTION
Brute force queries using vanilla elasticsearch.

Uses the [dense_vector field type](https://www.elastic.co/guide/en/elasticsearch/reference/master/dense-vector.html) to store vectors and [script_score queries for searching](https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-script-score-query.html).

It's quite slow. So far it looks like fashion-mnist is taking ~400ms per query on my i7-8750H.

ES also has a sparse_vector datatype, but it will be deprecated in 8.0.