### PR TITLE
fixes #190. Ubuntu 18.04 fix.

### DIFF
--- a/install/Dockerfile
+++ b/install/Dockerfile
@@ -2,6 +2,7 @@ FROM ubuntu:18.04
 
 RUN apt-get update
 RUN apt-get install -y python3-numpy python3-scipy python3-pip build-essential git
+RUN pip3 install -U pip
 
 WORKDIR /home/app
 COPY requirements.txt run_algorithm.py ./

--- a/install/Dockerfile.pynndescent
+++ b/install/Dockerfile.pynndescent
@@ -1,5 +1,5 @@
 FROM ann-benchmarks
 
-RUN pip3 install 'numba==0.46' 'llvmlite==0.33.0' 'numpy==1.17' scikit-learn
-RUN pip3 install 'pynndescent==0.4.4'
+RUN pip3 install 'numpy==1.17'
+RUN pip3 install pynndescent
 RUN python3 -c 'import pynndescent'


### PR DESCRIPTION
Tested on a fresh GCP Compute Engine VM running Ubuntu 18.04. 
Had to install `gcc` and `docker` first though.