### PR TITLE
closes #194. Also adds some resilience to failing packages

### DIFF
--- a/ann_benchmarks/plotting/utils.py
+++ b/ann_benchmarks/plotting/utils.py
@@ -87,7 +87,7 @@ def compute_all_metrics(true_nn_distances, run, properties, recompute=False):
 
 
 def generate_n_colors(n):
-    vs = numpy.linspace(0.4, 1.0, 7)
+    vs = numpy.linspace(0.3, 0.9, 7)
     colors = [(.9, .4, .4, 1.)]
 
     def euclidean(a, b):

--- a/install.py
+++ b/install.py
@@ -12,9 +12,14 @@ def build(library, args):
         q = " ".join(["--build-arg " + x.replace(" ", "\\ ") for x in args])
     else:
         q = ""
-    subprocess.check_call(
-        'docker build %s --rm -t ann-benchmarks-%s -f'
-        ' install/Dockerfile.%s .' % (q, library, library), shell=True)
+    
+    try:
+        subprocess.check_call(
+            'docker build %s --rm -t ann-benchmarks-%s -f'
+            ' install/Dockerfile.%s .' % (q, library, library), shell=True)
+        return {library: 'success'}
+    except subprocess.CalledProcessError:
+        return {library: 'fail'}
 
 
 def build_multiprocess(args):
@@ -56,9 +61,11 @@ if __name__ == "__main__":
         tags = [fn.split('.')[-1] for fn in os.listdir('install') if fn.startswith('Dockerfile.')]
 
         if args.proc == 1:
-            [build(tag, args.build_arg) for tag in tags]
+            install_status = [build(tag, args.build_arg) for tag in tags]
         else:
             pool = Pool(processes=args.proc)
-            pool.map(build_multiprocess, [(tag, args.build_arg) for tag in tags])
+            install_status = pool.map(build_multiprocess, [(tag, args.build_arg) for tag in tags])
             pool.close()
             pool.join()
+
+    print('\n\nInstall Status:\n' + '\n'.join(str(algo) for algo in install_status))


### PR DESCRIPTION
This PR addresses 2 things:
1. The colors in the plot are made slightly darker as reported in #194 
2. Individual algorithms that error while installing will not stop the installation of other algorithms. Instead, we will install whatever algorithm does install and print the install status of all algorithms at the end.