### PR TITLE
simplify the batch stuff further

### DIFF
--- a/ann_benchmarks/algorithms/definitions.py
+++ b/ann_benchmarks/algorithms/definitions.py
@@ -16,12 +16,6 @@ Definition = collections.namedtuple(
      'arguments', 'query_argument_groups', 'disabled'])
 
 
-def get_algorithm_name(name, batch):
-    if batch:
-        return name + "-batch"
-    return name
-
-
 def instantiate_algorithm(definition):
     print('Trying to instantiate %s.%s(%s)' %
           (definition.module, definition.constructor, definition.arguments))

--- a/ann_benchmarks/results.py
+++ b/ann_benchmarks/results.py
@@ -61,6 +61,7 @@ def load_all_results(dataset=None, count=None, batch_mode=False):
 
 def get_unique_algorithms():
     algorithms = set()
-    for properties, _ in load_all_results():
-        algorithms.add(properties['algo'])
+    for batch_mode in [False, True]:
+        for properties, _ in load_all_results(batch_mode=batch_mode):
+            algorithms.add(properties['algo'])
     return algorithms

--- a/ann_benchmarks/runner.py
+++ b/ann_benchmarks/runner.py
@@ -12,8 +12,7 @@ import numpy
 import psutil
 
 from ann_benchmarks.algorithms.definitions import (Definition,
-                                                   instantiate_algorithm,
-                                                   get_algorithm_name)
+                                                   instantiate_algorithm)
 from ann_benchmarks.datasets import get_dataset, DATASETS
 from ann_benchmarks.distance import metrics, dataset_transform
 from ann_benchmarks.results import store_results
@@ -142,8 +141,7 @@ function""" % (definition.module, definition.constructor, definition.arguments)
                 algo, X_train, X_test, distance, count, run_count, batch)
             descriptor["build_time"] = build_time
             descriptor["index_size"] = index_size
-            descriptor["algo"] = get_algorithm_name(
-                definition.algorithm, batch)
+            descriptor["algo"] = definition.algorithm
             descriptor["dataset"] = dataset
             store_results(dataset, count, definition,
                           query_arguments, descriptor, results, batch)

--- a/create_website.py
+++ b/create_website.py
@@ -10,7 +10,6 @@ import hashlib
 from jinja2 import Environment, FileSystemLoader
 
 from ann_benchmarks import results
-from ann_benchmarks.algorithms.definitions import get_algorithm_name
 from ann_benchmarks.datasets import get_dataset
 from ann_benchmarks.plotting.plot_variants import (all_plot_variants
                                                    as plot_variants)
@@ -178,11 +177,10 @@ def build_detail_site(data, label_func, j2_env, linestyles, batch=False):
         plot.create_plot(
             data_for_plot, False,
             False, True, 'k-nn', 'qps',
-            args.outputdir + get_algorithm_name(name, batch) + ".png",
+            args.outputdir + name + ('-batch' if batch else '') + '.png',
             linestyles, batch)
-        output_path = "".join([args.outputdir,
-                               get_algorithm_name(name, batch),
-                               ".html"])
+        output_path = \
+            args.outputdir + name + ('-batch' if batch else '') + '.html'
         with open(output_path, "w") as text_file:
             text_file.write(j2_env.get_template("detail_page.html").
                             render(title=label, plot_data=data,
@@ -215,8 +213,7 @@ def build_index_site(datasets, algorithms, j2_env, file_name):
         text_file.write(j2_env.get_template("summary.html").
                         render(title="ANN-Benchmarks",
                                dataset_with_distances=dataset_data,
-                               algorithms=algorithms,
-                               label_func=get_algorithm_name))
+                               algorithms=algorithms))
 
 
 def load_all_results():

--- a/plot.py
+++ b/plot.py
@@ -11,7 +11,7 @@ from ann_benchmarks.plotting.metrics import all_metrics as metrics
 from ann_benchmarks.plotting.utils import (get_plot_label, compute_metrics,
                                            create_linestyles, create_pointset)
 from ann_benchmarks.results import (store_results, load_all_results,
-                                    get_unique_algorithms, get_algorithm_name)
+                                    get_unique_algorithms)
 
 
 def create_plot(all_data, raw, x_log, y_log, xn, yn, fn_out, linestyles,
@@ -32,7 +32,7 @@ def create_plot(all_data, raw, x_log, y_log, xn, yn, fn_out, linestyles,
             handle2, = plt.plot(axs, ays, '-', label=algo, color=faded,
                                 ms=5, mew=2, lw=2, linestyle=linestyle,
                                 marker=marker)
-        labels.append(get_algorithm_name(algo, batch))
+        labels.append(algo)
 
     if x_log:
         plt.gca().set_xscale('log')

--- a/templates/summary.html
+++ b/templates/summary.html
@@ -23,13 +23,13 @@
                     {% for distance_data in dataset_with_distances[type] %}
                         <h3>Distance: {{ distance_data.name }} </h3>
                         {% for entry in distance_data.entries %}
-                            <a href="./{{label_func(entry.name, type == 'batch')}}.html">
+                            <a href="./{{ entry.name }}.html">
                             <div class="row" id="{{entry.name}}">
                                 <div class = "col-md-4 bg-success">
                                     <h4>{{entry.desc}}</h4>
                             </div>
                             <div class = "col-md-8">
-                                <img class = "img-responsive" src="{{label_func(entry.name, type == 'batch')}}.png" />
+                                <img class = "img-responsive" src="{{ entry.name }}.png" />
                             </div>
                         </div>
                         </a>
@@ -43,13 +43,13 @@
                         {% endfor %}
                     </ul>
                     {% for algo in algorithms[type].keys()%}
-                    <a href="./{{label_func(algo, type == 'batch')}}.html">
+                    <a href="./{{ algo }}.html">
                         <div class="row" id="{{algo}}">
                             <div class = "col-md-4 bg-success">
                                 <h4>{{algo}}</h4>
                         </div>
                         <div class = "col-md-8">
-                            <img class = "img-responsive" src="{{label_func(algo, type == 'batch')}}.png" />
+                            <img class = "img-responsive" src="{{ algo }}.png" />
                         </div>
                     </div>
                     </a>


### PR DESCRIPTION
my previous attempts to simplify the results code wrt batching introduced a bunch of issues that i guess i could have reverted, but instead i decided to keep digging a bit and i think i was able to simplify it even further and get things working again

1. batching is no longer a part of any algorithm name, just the filename
2. we do no longer infer whether batching is used from the filename, but instead read it from the result metadata

i think it's a bit cleaner