### PR TITLE
Fix batch mode behavior

### DIFF
--- a/ann_benchmarks/algorithms/base.py
+++ b/ann_benchmarks/algorithms/base.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from multiprocessing.pool import ThreadPool
 import psutil
 
 
@@ -19,9 +20,11 @@ class BaseANN(object):
         return []  # array of candidate indices
 
     def batch_query(self, X, n):
-        self.res = []
-        for q in X:
-            self.res.append(self.query(q, n))
+        """Provide all queries at once and let algorithm figure out
+           how to handle it. Default implementation uses a ThreadPool
+           to parallelize query processing."""
+        pool = ThreadPool()
+        self.res = pool.map(lambda q: self.query(q, n), X)
 
     def get_batch_results(self):
         return self.res

--- a/ann_benchmarks/main.py
+++ b/ann_benchmarks/main.py
@@ -41,8 +41,12 @@ def run_worker(cpu, args, queue):
         else:
             memory_margin = 500e6  # reserve some extra memory for misc stuff
             mem_limit = int((psutil.virtual_memory().available - memory_margin) / args.parallelism)
+            cpu_limit = str(cpu)
+            if args.batch:
+                cpu_limit = "0-%d" % (multiprocessing.cpu_count() - 1)
+
             run_docker(definition, args.dataset, args.count,
-                       args.runs, args.timeout, args.batch, str(cpu), mem_limit)
+                       args.runs, args.timeout, args.batch, cpu_limit, mem_limit)
 
 
 def main():
@@ -234,6 +238,8 @@ def main():
     queue = multiprocessing.Queue()
     for definition in definitions:
         queue.put(definition)
+    if args.batch and args.parallelism > 1:
+        raise Exception(f"Batch mode uses all available CPU resources, --parallelism should be set to 1. (Was: {args.parallelism})")
     workers = [multiprocessing.Process(target=run_worker, args=(i+1, args, queue))
                for i in range(args.parallelism)]
     [worker.start() for worker in workers]

--- a/create_website.py
+++ b/create_website.py
@@ -222,23 +222,23 @@ def load_all_results():
     all_runs_by_algorithm = {'batch': {}, 'non-batch': {}}
     cached_true_dist = []
     old_sdn = None
-    for properties, f in results.load_all_results():
-        sdn = get_run_desc(properties)
-        if sdn != old_sdn:
-            dataset = get_dataset(properties["dataset"])
-            cached_true_dist = list(dataset["distances"])
-            old_sdn = sdn
-        algo = properties["algo"]
-        ms = compute_all_metrics(
-            cached_true_dist, f, properties, args.recompute)
-        algo_ds = get_dataset_label(sdn)
-        idx = "non-batch"
-        if properties["batch_mode"]:
-            idx = "batch"
-        all_runs_by_algorithm[idx].setdefault(
-            algo, {}).setdefault(algo_ds, []).append(ms)
-        all_runs_by_dataset[idx].setdefault(
-            sdn, {}).setdefault(algo, []).append(ms)
+    for mode in ["non-batch", "batch"]:
+        for properties, f in results.load_all_results(batch_mode=(mode == "batch")):
+            sdn = get_run_desc(properties)
+            if sdn != old_sdn:
+                dataset = get_dataset(properties["dataset"])
+                cached_true_dist = list(dataset["distances"])
+                old_sdn = sdn
+            algo_ds = get_dataset_label(sdn)
+            desc_suffix = ("-batch" if mode == "batch" else "")
+            algo = properties["algo"] + desc_suffix
+            sdn += desc_suffix
+            ms = compute_all_metrics(
+                cached_true_dist, f, properties, args.recompute)
+            all_runs_by_algorithm[mode].setdefault(
+                algo, {}).setdefault(algo_ds, []).append(ms)
+            all_runs_by_dataset[mode].setdefault(
+                sdn, {}).setdefault(algo, []).append(ms)
 
     return (all_runs_by_dataset, all_runs_by_algorithm)
 


### PR DESCRIPTION
A follow-up on #201. I think the batch mode file handling works nicely again (except #203). 

However, the whole docker parallelization rendered batch mode in Docker useless and this PR fixes this. Batch mode was meant to allow an implementation to go 'all in' with CPU/GPU resources. It doesn't help an implementation much if it receives all the queries at once if it then has to solve it in a single thread :-) 

I tried to find a fix that was minimally invasive with the rest of the code base. Let me know what you think.  