### PR TITLE
Fix result caching

### DIFF
--- a/ann_benchmarks/main.py
+++ b/ann_benchmarks/main.py
@@ -155,7 +155,7 @@ def main():
         for query_arguments in query_argument_groups:
             fn = get_result_filename(args.dataset,
                                      args.count, definition,
-                                     query_arguments, args.batch)
+                                     query_arguments, args.batch) + '.hdf5'
             if args.force or not os.path.exists(fn):
                 not_yet_run.append(query_arguments)
         if not_yet_run:


### PR DESCRIPTION
Result files end in .hdf5 but the current code neglects this, so it never finds the file, even if the config has already been run.