### PR TITLE
add NGT-QG

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Evaluated
 * [Datasketch](https://github.com/ekzhu/datasketch)
 * [PyNNDescent](https://github.com/lmcinnes/pynndescent)
 * [MRPT](https://github.com/teemupitkanen/mrpt)
-* [NGT](https://github.com/yahoojapan/NGT): ONNG, PANNG
+* [NGT](https://github.com/yahoojapan/NGT): ONNG, PANNG, QG
 * [SPTAG](https://github.com/microsoft/SPTAG)
 * [PUFFINN](https://github.com/puffinn/puffinn)
 * [N2](https://github.com/kakao/n2)

--- a/algos.yaml
+++ b/algos.yaml
@@ -327,6 +327,16 @@ float:
         onng-80-60-graph:
            args : [{'edge': 100, 'outdegree': 10, 'indegree': 80, 'search_edge': 60, 'tree': False}]
            query-args : [[0.6, 0.9, 0.995, 0.998, 1.0, 1.01, 1.02, 1.05, 1.07]]
+    NGT-qg:
+      docker-tag: ann-benchmarks-ngt
+      module: ann_benchmarks.algorithms.qg_ngt
+      constructor : QG
+      base-args : ["@metric", "Float", 0.1]
+      run-groups :
+        me-96:
+           args : [{'edge': 100, 'outdegree': 64, 'indegree': 120, 'max_edge': 96}]
+           query-args : [[1.5, 1.7, 2.0, 2.5, 3.0, 5.0, 8.0],
+                         [0.9, 0.95, 1.0, 1.01, 1.02, 1.03, 1.04, 1.05, 1.06]]
     mrpt:
       docker-tag: ann-benchmarks-mrpt
       module: ann_benchmarks.algorithms.mrpt


### PR DESCRIPTION
Thank you for your time and effort to provide and maintain your awesome benchmarks.
We have implemented a quantized graph into [NGT](https://github.com/yahoojapan/NGT). I'd like you to merge the NGT-QG PR including a bug fix of ONNG to your ann benchmarks. The followings are its results (glove-100 and shift-128) on the AWS c5.4xlarge instance. Unfortunately, it takes about 3.5 hours that is longer than the default timeout [2 hours](https://github.com/erikbern/ann-benchmarks/blob/master/ann_benchmarks/main.py#L97) to produce the result of glove-100. I wish I could use multiple cores to build the indexes.

![glove-100-angular](https://user-images.githubusercontent.com/20806009/104861282-97089d00-5972-11eb-924e-0b7220adbf28.png)

![sift-128-euclidean](https://user-images.githubusercontent.com/20806009/104861359-dc2ccf00-5972-11eb-928e-6334879e65a0.png)
