### PR TITLE
Updated faiss docker file

### DIFF
--- a/install/Dockerfile.faiss
+++ b/install/Dockerfile.faiss
@@ -3,7 +3,7 @@ FROM ann-benchmarks
 RUN apt-get update && apt-get install -y libopenblas-base libopenblas-dev libpython3-dev swig python3-dev libssl-dev wget
 RUN wget https://github.com/Kitware/CMake/releases/download/v3.18.3/cmake-3.18.3-Linux-x86_64.sh && mkdir cmake && sh cmake-3.18.3-Linux-x86_64.sh --skip-license --prefix=cmake && rm cmake-3.18.3-Linux-x86_64.sh
 RUN git clone https://github.com/facebookresearch/faiss lib-faiss
-RUN cd lib-faiss && ../cmake/bin/cmake -DFAISS_ENABLE_GPU=OFF -DPython_EXECUTABLE=/usr/bin/python3 -B build .
+RUN cd lib-faiss && ../cmake/bin/cmake -DFAISS_OPT_LEVEL=avx2 -DCMAKE_BUILD_TYPE=Release -DFAISS_ENABLE_GPU=OFF -DPython_EXECUTABLE=/usr/bin/python3 -B build .
 RUN cd lib-faiss && make -C build -j4
 RUN cd lib-faiss && cd build && cd faiss && cd python && python3 setup.py install && cd && rm -rf cmake
 RUN python3 -c 'import faiss; print(faiss.IndexFlatL2)'


### PR DESCRIPTION
All FAISS implementations turned out pretty slow in the last benchmark run. This PR fixes that.