### PR TITLE
Stop container after timeout.

### DIFF
--- a/ann_benchmarks/runner.py
+++ b/ann_benchmarks/runner.py
@@ -266,5 +266,4 @@ def run_docker(definition, dataset, count, runs, timeout, batch, cpu_limit,
         logger.error('Container.wait for container %s failed with exception' % container.short_id)
         traceback.print_exc()
     finally:
-        pass
-        # container.remove(force=True)
+        container.remove(force=True)


### PR DESCRIPTION
7d767f53210981fac8fe2bfb559ce1410b1a1af0 sneaked in a bug so that it doesn't stop containers after running into a timeout. This had the nice effect that some containers would later share the CPU with a container that was supposed to be killed.