### PR TITLE
Fix install milvus failed.

### DIFF
--- a/install/Dockerfile.milvus
+++ b/install/Dockerfile.milvus
@@ -1,7 +1,6 @@
 # Install Milvus
 FROM milvusdb/milvus:0.6.0-cpu-d120719-2b40dd as milvus
-RUN apt-get update
-RUN apt-get install -y wget
+RUN apt-get update && apt-get install -y wget
 RUN wget https://raw.githubusercontent.com/milvus-io/docs/master/v0.6.0/assets/server_config.yaml
 RUN sed -i 's/cpu_cache_capacity: 16/cpu_cache_capacity: 4/' server_config.yaml  # otherwise my Docker blows up
 RUN mv server_config.yaml /var/lib/milvus/conf/server_config.yaml


### PR DESCRIPTION
Build milvus by `python install.py --algorithm milvus ` repeatedly will be failed, because that  docker sees the initial and modified instructions as identical and reuses the cache from previous steps. As a result the apt-get update is not executed because the build uses the cached version. Because the apt-get update is not run.

For details, please refer to this article: https://docs.docker.com/develop/develop-images/dockerfile_best-practices/