### PR TITLE
Fix creating 'Benchmarks for Batched Queries' website.

### DIFF
--- a/create_website.py
+++ b/create_website.py
@@ -177,10 +177,10 @@ def build_detail_site(data, label_func, j2_env, linestyles, batch=False):
         plot.create_plot(
             data_for_plot, False,
             'linear', 'log', 'k-nn', 'qps',
-            args.outputdir + name + ('-batch' if batch else '') + '.png',
+            args.outputdir + name + '.png',
             linestyles, batch)
         output_path = \
-            args.outputdir + name + ('-batch' if batch else '') + '.html'
+            args.outputdir + name + '.html'
         with open(output_path, "w") as text_file:
             text_file.write(j2_env.get_template("detail_page.html").
                             render(title=label, plot_data=data,


### PR DESCRIPTION
When generating batch results, the "batch" suffix was repeatedly added, resulting in the file not being found on the web page.

![image](https://user-images.githubusercontent.com/38530078/112439365-fe343a80-8d83-11eb-8f55-2355ff7e1b37.png)


![image](https://user-images.githubusercontent.com/38530078/112439503-2459da80-8d84-11eb-971a-dfb9dea0567b.png)

After fixed:

![image](https://user-images.githubusercontent.com/38530078/112439890-9a5e4180-8d84-11eb-82fb-4b42e5246ebe.png)

![image](https://user-images.githubusercontent.com/38530078/112440040-cda0d080-8d84-11eb-9bce-985148a0521b.png)

