### PR TITLE
Use sparse datasets for jaccard similarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Principles
 * Focus on datasets that fit in RAM. Out of core ANN could be the topic of a later comparison.
 * We mainly support CPU-based ANN algorithms. GPU support exists for FAISS, but it has to be compiled with GPU support locally and experiments must be run using the flags `--local --batch`. 
 * Do proper train/test set of index data and query points.
-* Note that set similarity was supported in the past. This might hopefully be added back soon.
+* Note that we consider that set similarity datasets are sparse and thus we pass a **sorted** array of integers to algorithms to represent the set of each user.
 
 
 Authors

--- a/ann_benchmarks/datasets.py
+++ b/ann_benchmarks/datasets.py
@@ -2,7 +2,6 @@ import h5py
 import numpy
 import os
 import random
-import sys
 
 from urllib.request import urlopen
 from urllib.request import urlretrieve
@@ -34,18 +33,24 @@ def get_dataset(which):
             print("Creating dataset locally")
             DATASETS[which](hdf5_fn)
     hdf5_f = h5py.File(hdf5_fn, 'r')
-    return hdf5_f
+
+    dimension = hdf5_f.attrs['dimension'] if 'dimension' in hdf5_f.attrs else len(hdf5_f['train'][0])
+
+    return hdf5_f, dimension
 
 
 # Everything below this line is related to creating datasets
 # You probably never need to do this at home,
 # just rely on the prepared datasets at http://ann-benchmarks.com
 
+
 def write_output(train, test, fn, distance, point_type='float', count=100):
     from ann_benchmarks.algorithms.bruteforce import BruteForceBLAS
     n = 0
     f = h5py.File(fn, 'w')
+    f.attrs['type'] = 'dense'
     f.attrs['distance'] = distance
+    f.attrs['dimension'] = len(train[0])
     f.attrs['point_type'] = point_type
     print('train size: %9d * %4d' % train.shape)
     print('test size:  %9d * %4d' % test.shape)
@@ -56,10 +61,8 @@ def write_output(train, test, fn, distance, point_type='float', count=100):
     neighbors = f.create_dataset('neighbors', (len(test), count), dtype='i')
     distances = f.create_dataset('distances', (len(test), count), dtype='f')
     bf = BruteForceBLAS(distance, precision=train.dtype)
-    train = dataset_transform[distance](train)
-    test = dataset_transform[distance](test)
+
     bf.fit(train)
-    queries = []
     for i, x in enumerate(test):
         if i % 1000 == 0:
             print('%d/%d...' % (i, len(test)))
@@ -69,10 +72,49 @@ def write_output(train, test, fn, distance, point_type='float', count=100):
         distances[i] = [d for _, d in res]
     f.close()
 
+"""
+param: train and test are arrays of arrays of indices.
+"""
+def write_sparse_output(train, test, fn, distance, dimension, count=100):
+    from ann_benchmarks.algorithms.bruteforce import BruteForceBLAS
+    f = h5py.File(fn, 'w')
+    f.attrs['type'] = 'sparse'
+    f.attrs['distance'] = distance
+    f.attrs['dimension'] = dimension
+    f.attrs['point_type'] = 'bit'
+    print('train size: %9d * %4d' % (train.shape[0], dimension))
+    print('test size:  %9d * %4d' % (test.shape[0], dimension))
 
-def train_test_split(X, test_size=10000):
+    train = numpy.array(list(map(sorted, train)))
+    test = numpy.array(list(map(sorted, test)))
+
+    flat_train = numpy.hstack(train.flatten())
+    flat_test = numpy.hstack(test.flatten())
+
+    f.create_dataset('train', (len(flat_train),), dtype=flat_train.dtype)[:] = flat_train
+    f.create_dataset('test', (len(flat_test),), dtype=flat_test.dtype)[:] = flat_test
+    neighbors = f.create_dataset('neighbors', (len(test), count), dtype='i')
+    distances = f.create_dataset('distances', (len(test), count), dtype='f')
+
+    f.create_dataset('size_test', (len(test),), dtype='i')[:] = list(map(len, test))
+    f.create_dataset('size_train', (len(train),), dtype='i')[:] = list(map(len, train))
+
+    bf = BruteForceBLAS(distance, precision=train.dtype)
+    bf.fit(train)
+    for i, x in enumerate(test):
+        if i % 1000 == 0:
+            print('%d/%d...' % (i, len(test)))
+        res = list(bf.query_with_distances(x, count))
+        res.sort(key=lambda t: t[-1])
+        neighbors[i] = [j for j, _ in res]
+        distances[i] = [d for _, d in res]
+    f.close()
+
+def train_test_split(X, test_size=10000, dimension=None):
     import sklearn.model_selection
-    print('Splitting %d*%d into train/test' % X.shape)
+    if dimension == None:
+        dimension = X.shape[1]
+    print('Splitting %d*%d into train/test' % (X.shape[0], dimension))
     return sklearn.model_selection.train_test_split(
         X, test_size=test_size, random_state=1)
 
@@ -311,41 +353,29 @@ def kosarak(out_fn):
     url = 'http://fimi.uantwerpen.be/data/%s' % local_fn
     download(url, local_fn)
 
+    X = []
+    dimension = 0
     with gzip.open('kosarak.dat.gz', 'r') as f:
         content = f.readlines()
         # preprocess data to find sets with more than 20 elements
         # keep track of used ids for reenumeration
-        ids = {}
-        next_id = 0
-        cnt = 0
         for line in content:
             if len(line.split()) >= min_elements:
-                cnt += 1
-                for x in line.split():
-                    if int(x) not in ids:
-                        ids[int(x)] = next_id
-                        next_id += 1
+                X.append(list(map(int, line.split())))
+                dimension = max(dimension, max(X[-1]) + 1)
 
-    X = numpy.zeros((cnt, len(ids)), dtype=numpy.bool)
-    i = 0
-    for line in content:
-        if len(line.split()) >= min_elements:
-            for x in line.split():
-                X[i][ids[int(x)]] = 1
-            i += 1
-
-    X_train, X_test = train_test_split(numpy.array(X), test_size=500)
-    write_output(X_train, X_test, out_fn, 'jaccard', 'bit')
+    X_train, X_test = train_test_split(numpy.array(X), test_size=500, dimension=dimension)
+    write_sparse_output(X_train, X_test, out_fn, 'jaccard', dimension)
 
 def random_jaccard(out_fn, n=10000, size=50, universe=80):
     random.seed(1)
     l = list(range(universe))
-    X = numpy.zeros((n, universe), dtype=numpy.bool)
-    for i in range(len(X)):
-        for j in random.sample(l, size):
-            X[i][j] = True
-    X_train, X_test = train_test_split(X, test_size=100)
-    write_output(X_train, X_test, out_fn, 'jaccard', 'bit')
+    X = []
+    for i in range(n):
+        X.append(random.sample(l, size))
+
+    X_train, X_test = train_test_split(numpy.array(X), test_size=100, dimension=universe)
+    write_sparse_output(X_train, X_test, out_fn, 'jaccard', universe)
 
 
 

--- a/ann_benchmarks/datasets.py
+++ b/ann_benchmarks/datasets.py
@@ -34,6 +34,7 @@ def get_dataset(which):
             DATASETS[which](hdf5_fn)
     hdf5_f = h5py.File(hdf5_fn, 'r')
 
+    # here for backward compatibility, to ensure old datasets can still be used with newer versions
     dimension = hdf5_f.attrs['dimension'] if 'dimension' in hdf5_f.attrs else len(hdf5_f['train'][0])
 
     return hdf5_f, dimension
@@ -85,6 +86,7 @@ def write_sparse_output(train, test, fn, distance, dimension, count=100):
     print('train size: %9d * %4d' % (train.shape[0], dimension))
     print('test size:  %9d * %4d' % (test.shape[0], dimension))
 
+    # We ensure the sets are sorted
     train = numpy.array(list(map(sorted, train)))
     test = numpy.array(list(map(sorted, test)))
 

--- a/ann_benchmarks/distance.py
+++ b/ann_benchmarks/distance.py
@@ -61,4 +61,6 @@ def dataset_transform(dataset):
     if dataset.attrs.get('type', 'dense') != 'sparse':
         return np.array(dataset['train']), np.array(dataset['test'])
     
+    # we store the dataset as a list of integers, accompanied by a list of lengths in hdf5
+    # so we transform it back to the format expected by the algorithms here (array of array of ints)
     return sparse_to_lists(dataset['train'], dataset['size_train']), sparse_to_lists(dataset['test'], dataset['size_test'])

--- a/ann_benchmarks/distance.py
+++ b/ann_benchmarks/distance.py
@@ -48,9 +48,17 @@ metrics = {
     }
 }
 
-dataset_transform = {
-    'hamming': lambda X: X,
-    'euclidean': lambda X: X,
-    'angular': lambda X: X,
-    'jaccard' : lambda X: transform_dense_to_sparse(X)
-}
+def sparse_to_lists(data, lengths):
+    X = []
+    index = 0
+    for l in lengths:
+        X.append(data[index:index+l])
+        index += l
+    
+    return X
+
+def dataset_transform(dataset):
+    if dataset.attrs.get('type', 'dense') != 'sparse':
+        return np.array(dataset['train']), np.array(dataset['test'])
+    
+    return sparse_to_lists(dataset['train'], dataset['size_train']), sparse_to_lists(dataset['test'], dataset['size_test'])

--- a/ann_benchmarks/main.py
+++ b/ann_benchmarks/main.py
@@ -139,8 +139,7 @@ def main():
     if os.path.exists(INDEX_DIR):
         shutil.rmtree(INDEX_DIR)
 
-    dataset = get_dataset(args.dataset)
-    dimension = len(dataset['train'][0])  # TODO(erikbern): ugly
+    dataset, dimension = get_dataset(args.dataset)
     point_type = dataset.attrs.get('point_type', 'float')
     distance = dataset.attrs['distance']
     definitions = get_definitions(

--- a/ann_benchmarks/runner.py
+++ b/ann_benchmarks/runner.py
@@ -103,15 +103,14 @@ error: query argument groups have been specified for %s.%s(%s), but the \
 algorithm instantiated from it does not implement the set_query_arguments \
 function""" % (definition.module, definition.constructor, definition.arguments)
 
-    D = get_dataset(dataset)
+    D, dimension = get_dataset(dataset)
     X_train = numpy.array(D['train'])
     X_test = numpy.array(D['test'])
     distance = D.attrs['distance']
-    print('got a train set of size (%d * %d)' % X_train.shape)
+    print('got a train set of size (%d * %d)' % (X_train.shape[0], dimension))
     print('got %d queries' % len(X_test))
 
-    X_train = dataset_transform[distance](X_train)
-    X_test = dataset_transform[distance](X_test)
+    X_train, X_test = dataset_transform(D)
 
     try:
         prepared_queries = False

--- a/create_website.py
+++ b/create_website.py
@@ -226,7 +226,7 @@ def load_all_results():
         for properties, f in results.load_all_results(batch_mode=(mode == "batch")):
             sdn = get_run_desc(properties)
             if sdn != old_sdn:
-                dataset = get_dataset(properties["dataset"])
+                dataset, _ = get_dataset(properties["dataset"])
                 cached_true_dist = list(dataset["distances"])
                 old_sdn = sdn
             algo_ds = get_dataset_label(sdn)

--- a/plot.py
+++ b/plot.py
@@ -144,7 +144,7 @@ if __name__ == "__main__":
         args.output = 'results/%s.png' % (args.dataset + ('-batch' if args.batch else ''))
         print('writing output to %s' % args.output)
 
-    dataset = get_dataset(args.dataset)
+    dataset, _ = get_dataset(args.dataset)
     count = int(args.count)
     unique_algorithms = get_unique_algorithms()
     results = load_all_results(args.dataset, count, args.batch)


### PR DESCRIPTION
Following @maumueller's comment in https://github.com/erikbern/ann-benchmarks/pull/234#issuecomment-836243852, here is an implementation of sparse datasets to be closer to jaccard similarity requirements.

Note however that this change is not backward compatible for the kosarak dataset.
Is it a no go and should I add some backward compatibility layers?