### PR TITLE
Make Puffinn algorithm compatible with sparse dataset format

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -59,6 +59,8 @@ jobs:
             dataset: random-xs-20-angular
           - library: puffinn
             dataset: random-s-jaccard
+          - library: pynndescent
+            dataset: random-s-jaccard
       fail-fast: false
 
     steps:

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -57,6 +57,8 @@ jobs:
             dataset: random-xs-20-angular
           - library: diskann
             dataset: random-xs-20-angular
+          - library: puffinn
+            dataset: random-s-jaccard
       fail-fast: false
 
     steps:

--- a/ann_benchmarks/algorithms/puffinn.py
+++ b/ann_benchmarks/algorithms/puffinn.py
@@ -30,8 +30,7 @@ class Puffinn(BaseANN):
             self.index = puffinn.Index(self.metric, dimensions, self.space,\
                     hash_function=self.hash_function, hash_source=self.hash_source)
         for i, x in enumerate(X):
-            if self.metric == 'angular':
-                x = x.tolist()
+            x = x.tolist()
             self.index.insert(x)
         self.index.rebuild()
 
@@ -39,8 +38,7 @@ class Puffinn(BaseANN):
         self.recall = recall
 
     def query(self, v, n):
-        if self.metric == 'angular':
-            v = v.tolist()
+        v = v.tolist()
         return self.index.search(v, n, self.recall)
 
     def __str__(self):

--- a/ann_benchmarks/distance.py
+++ b/ann_benchmarks/distance.py
@@ -15,19 +15,6 @@ def jaccard(a, b):
     intersect = len(set(a) & set(b))
     return intersect / (float)(len(a) + len(b) - intersect)
 
-def transform_dense_to_sparse(X):
-    """Converts the n * m dataset into a sparse format
-    that only holds the non-zero entries (Jaccard)."""
-    # get list of indices of non-zero elements
-    indices = np.transpose(np.where(X))
-    keys = []
-    for _, js in itertools.groupby(indices, lambda ij: ij[0]):
-        keys.append([j for _, j in js])
-
-    assert len(X) == len(keys)
-
-    return keys
-
 metrics = {
     'hamming': {
         'distance': lambda a, b: pdist(a, b, "hamming"),

--- a/test/test-jaccard.py
+++ b/test/test-jaccard.py
@@ -1,6 +1,6 @@
 import unittest
 import numpy
-from ann_benchmarks.distance import jaccard, transform_dense_to_sparse
+from ann_benchmarks.distance import jaccard
 
 class TestJaccard(unittest.TestCase):
     def setUp(self):
@@ -16,8 +16,4 @@ class TestJaccard(unittest.TestCase):
         self.assertAlmostEqual(jaccard(a, a), 1.0)
         self.assertAlmostEqual(jaccard(a, c), 0.5)
         self.assertAlmostEqual(jaccard(c, d), 0.0)
-
-    def test_transformation(self):
-        X = numpy.array([[True, False, False], [True, False, True], [False, False, True]])
-        self.assertEqual(transform_dense_to_sparse(X), [[0],[0, 2], [2]])
 


### PR DESCRIPTION
Sorry my two PRs (https://github.com/erikbern/ann-benchmarks/pull/235 and https://github.com/erikbern/ann-benchmarks/pull/234) were not compatible with each other, I should have added a note.
So here's a fix, and I added puffinn with jaccard to the tests set to make it easier to detect in the future.