### PR TITLE
Add Vespa HNSW to ANN Benchmarks

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -61,6 +61,8 @@ jobs:
             dataset: random-s-jaccard
           - library: pynndescent
             dataset: random-s-jaccard
+          - library: vespa
+            dataset: random-xs-20-angular
       fail-fast: false
 
     steps:

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Evaluated
 * [Elastiknn](https://github.com/alexklibisz/elastiknn)
 * [OpenDistro Elasticsearch KNN](https://github.com/opendistro-for-elasticsearch/k-NN)
 * [DiskANN](https://github.com/microsoft/diskann): Vamana, Vamana-PQ
+* [Vespa](https://github.com/vespa-engine/vespa)
 
 Data sets
 =========

--- a/algos.yaml
+++ b/algos.yaml
@@ -603,6 +603,48 @@ float:
           arg-groups:
             - {"M": 48,  "efConstruction": 500}
           query-args: [[10, 20, 40, 80, 120, 200, 400, 600, 800]]
+    hnsw(vespa):
+      docker-tag: ann-benchmarks-vespa
+      module: ann_benchmarks.algorithms.vespa
+      constructor: VespaHnsw
+      base-args: ["@metric", "@dimension"]
+      run-groups:
+        M-4:
+          arg-groups:
+            - {"M": 4, "efConstruction": 500}
+          query-args: [[10, 20, 40, 80, 120, 200, 400, 600, 800]]
+        M-8:
+          arg-groups:
+            - {"M": 8, "efConstruction": 500}
+          query-args: [[10, 20, 40, 80, 120, 200, 400, 600, 800]]
+        M-12:
+          arg-groups:
+            - {"M": 12, "efConstruction": 500}
+          query-args: [[10, 20, 40, 80, 120, 200, 400, 600, 800]]
+        M-16:
+          arg-groups:
+            - {"M": 16, "efConstruction": 500}
+          query-args: [[10, 20, 40, 80, 120, 200, 400, 600, 800]]
+        M-24:
+          arg-groups:
+            - {"M": 24, "efConstruction": 500}
+          query-args: [[10, 20, 40, 80, 120, 200, 400, 600, 800]]
+        M-36:
+          arg-groups:
+            - {"M": 36, "efConstruction": 500}
+          query-args: [[10, 20, 40, 80, 120, 200, 400, 600, 800]]
+        M-48:
+          arg-groups:
+            - {"M": 48, "efConstruction": 500}
+          query-args: [[10, 20, 40, 80, 120, 200, 400, 600, 800]]
+        M-64:
+          arg-groups:
+            - {"M": 64, "efConstruction": 500}
+          query-args: [[10, 20, 40, 80, 120, 200, 400, 600, 800]]
+        M-96:
+          arg-groups:
+            - {"M": 96, "efConstruction": 500}
+          query-args: [[10, 20, 40, 80, 120, 200, 400, 600, 800]]
 
   angular:
     vamana(diskann):
@@ -844,6 +886,48 @@ float:
         M-48:
           arg-groups:
             - {"M": 48,  "efConstruction": 500}
+          query-args: [[10, 20, 40, 80, 120, 200, 400, 600, 800]]
+    hnsw(vespa):
+      docker-tag: ann-benchmarks-vespa
+      module: ann_benchmarks.algorithms.vespa
+      constructor: VespaHnsw
+      base-args: ["@metric", "@dimension"]
+      run-groups:
+        M-4:
+          arg-groups:
+            - {"M": 4, "efConstruction": 500}
+          query-args: [[10, 20, 40, 80, 120, 200, 400, 600, 800]]
+        M-8:
+          arg-groups:
+            - {"M": 8, "efConstruction": 500}
+          query-args: [[10, 20, 40, 80, 120, 200, 400, 600, 800]]
+        M-12:
+          arg-groups:
+            - {"M": 12, "efConstruction": 500}
+          query-args: [[10, 20, 40, 80, 120, 200, 400, 600, 800]]
+        M-16:
+          arg-groups:
+            - {"M": 16, "efConstruction": 500}
+          query-args: [[10, 20, 40, 80, 120, 200, 400, 600, 800]]
+        M-24:
+          arg-groups:
+            - {"M": 24, "efConstruction": 500}
+          query-args: [[10, 20, 40, 80, 120, 200, 400, 600, 800]]
+        M-36:
+          arg-groups:
+            - {"M": 36, "efConstruction": 500}
+          query-args: [[10, 20, 40, 80, 120, 200, 400, 600, 800]]
+        M-48:
+          arg-groups:
+            - {"M": 48, "efConstruction": 500}
+          query-args: [[10, 20, 40, 80, 120, 200, 400, 600, 800]]
+        M-64:
+          arg-groups:
+            - {"M": 64, "efConstruction": 500}
+          query-args: [[10, 20, 40, 80, 120, 200, 400, 600, 800]]
+        M-96:
+          arg-groups:
+            - {"M": 96, "efConstruction": 500}
           query-args: [[10, 20, 40, 80, 120, 200, 400, 600, 800]]
 
 bit:

--- a/ann_benchmarks/algorithms/vespa.py
+++ b/ann_benchmarks/algorithms/vespa.py
@@ -1,0 +1,47 @@
+from ann_benchmarks.algorithms.base import BaseANN
+from vespa_ann_benchmark import DistanceMetric, HnswIndexParams, HnswIndex
+import time
+
+# Class using the Vespa implementation of an HNSW index for nearest neighbor
+# search over data points in a high dimensional vector space.
+#
+# To use nearest neighbor search in a Vespa application,
+# see https://docs.vespa.ai/en/approximate-nn-hnsw.html for more details.
+class VespaHnswBase(BaseANN):
+    def __init__(self, enable_normalize, metric, dimension, param):
+        if metric not in ('angular', 'euclidean'):
+            raise NotImplementedError(
+                "VespaHnsw doesn't support metric %s" % metric)
+        self.metric = {'angular': DistanceMetric.Angular, 'euclidean': DistanceMetric.Euclidean}[metric]
+        normalize = False
+        if self.metric == DistanceMetric.Angular and enable_normalize:
+            normalize = True
+            self.metric = DistanceMetric.InnerProduct
+        self.param = param
+        self.neighbors_to_explore_at_insert = param.get("efConstruction", 200)
+        self.max_links_per_node = param.get("M", 8)
+        self.dimension = dimension
+        self.neighbors_to_explore = 200
+        self.name = 'VespaHnsw()'
+        self.index = HnswIndex(dimension, HnswIndexParams(self.max_links_per_node, self.neighbors_to_explore_at_insert, self.metric, False), normalize)
+
+    def fit(self, X):
+        for i, x in enumerate(X):
+            self.index.set_vector(i, x)
+
+    def set_query_arguments(self, ef):
+        print("VespaHnsw: ef = " + str(ef))
+        self.neighbors_to_explore = ef
+
+    def query(self, v, n):
+        return [index for index, _ in self.query_with_distances(v, n)]
+
+    def query_with_distances(self, v, n):
+        return self.index.find_top_k(n, v, self.neighbors_to_explore)
+
+class VespaHnsw(VespaHnswBase):
+    def __init__(self, metric, dimension, param):
+        super().__init__(True, metric, dimension, param)
+
+    def __str__(self):
+        return 'VespaHnsw ({}, ef: {})'.format(self.param, self.neighbors_to_explore)

--- a/install/Dockerfile.vespa
+++ b/install/Dockerfile.vespa
@@ -1,0 +1,17 @@
+FROM centos:7
+
+RUN yum -y install epel-release && \
+    yum -y install centos-release-scl && \
+    yum -y --setopt=skip_missing_names_on_install=False install gcc make git python3-devel && \
+    python3 -m pip install --upgrade pip setuptools wheel && \
+    yum-config-manager --add-repo https://copr.fedorainfracloud.org/coprs/g/vespa/vespa/repo/epel-7/group_vespa-vespa-epel-7.repo && \
+    yum -y --setopt=skip_missing_names_on_install=False --enablerepo=epel-testing install vespa-ann-benchmark
+
+WORKDIR /home/app
+
+COPY requirements.txt run_algorithm.py ./
+
+RUN python3 -m pip install -r requirements.txt && \
+    python3 -m pip install /opt/vespa/libexec/vespa_ann_benchmark
+
+ENTRYPOINT ["python3", "run_algorithm.py"]


### PR DESCRIPTION
[Vespa](https://vespa.ai/) is an open source big data serving engine that supports approximate nearest neighbor search by using an in-memory HNSW index. Vespa implements a modified version of the Hierarchical Navigable Small World (HNSW) graphs algorithm ([paper](https://arxiv.org/abs/1603.09320)). The Vespa implementation supports:

- Combining HNSW lookups with metadata filters and text search
- Real-time index updates
- Multi-threaded indexing and searching

For more details see [Approximate Nearest Neighbor Search using HNSW Index](https://docs.vespa.ai/en/approximate-nn-hnsw.html).

This integration adds benchmarking directly towards the Vespa HNSW index and experiments show comparable performance with other HNSW algorithms. The Vespa HNSW index has less co-localisation of data in memory due to the extra functionality supported, and the performance differences with the other HNSW algorithms are mainly due to cache misses. The experiments were conducted on an Ubuntu 18 VM with Intel i7-8700k CPU and 48 GB of memory.

glove-100-angular (k = 10):
![image](https://user-images.githubusercontent.com/19347706/121321374-548a3180-c90e-11eb-94f6-46dbfe36aa92.png)

sift-128-euclidean (k = 10):
![image](https://user-images.githubusercontent.com/19347706/121321614-8bf8de00-c90e-11eb-9a39-13ed3c2443c0.png)
