### PR TITLE
Fixed using @dimension in yaml file 

### DIFF
--- a/ann_benchmarks/datasets.py
+++ b/ann_benchmarks/datasets.py
@@ -35,7 +35,8 @@ def get_dataset(which):
     hdf5_f = h5py.File(hdf5_fn, 'r')
 
     # here for backward compatibility, to ensure old datasets can still be used with newer versions
-    dimension = hdf5_f.attrs['dimension'] if 'dimension' in hdf5_f.attrs else len(hdf5_f['train'][0])
+    # cast to integer because the json parser (later on) cannot interpret numpy integers
+    dimension = int(hdf5_f.attrs['dimension']) if 'dimension' in hdf5_f.attrs else len(hdf5_f['train'][0])
 
     return hdf5_f, dimension
 


### PR DESCRIPTION
Looking at #250 I noticed the following bug that would occur when running on new datasets: 

```
$ python3 run.py --dataset mnist-784-euclidean --algorithm annoy
Traceback (most recent call last):
  File "run.py", line 6, in <module>
    main()
  File "/home/maau/ann-benchmarks/ann_benchmarks/main.py", line 159, in main
    fn = get_result_filename(args.dataset,
  File "/home/maau/ann-benchmarks/ann_benchmarks/results.py", line 20, in get_result_filename
    d.append(re.sub(r'\W+', '_', json.dumps(data, sort_keys=True))
  File "/usr/lib/python3.8/json/__init__.py", line 234, in dumps
    return cls(
  File "/usr/lib/python3.8/json/encoder.py", line 199, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/usr/lib/python3.8/json/encoder.py", line 257, in iterencode
    return _iterencode(o, 0)
  File "/usr/lib/python3.8/json/encoder.py", line 179, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
TypeError: Object of type int64 is not JSON serializable
```

The reason for this bug is that the number of dimensions is a numpy integer in the hdf5 file, and the json parser cannot work with it. Manually casting to int fixes it.