### PR TITLE
Fix stdout to be unbuffered

### DIFF
--- a/install/Dockerfile
+++ b/install/Dockerfile
@@ -8,4 +8,4 @@ WORKDIR /home/app
 COPY requirements.txt run_algorithm.py ./
 RUN pip3 install -r requirements.txt
 
-ENTRYPOINT ["python3", "run_algorithm.py"]
+ENTRYPOINT ["python3", "-u", "run_algorithm.py"]

--- a/install/Dockerfile.milvus
+++ b/install/Dockerfile.milvus
@@ -22,6 +22,6 @@ RUN pip3 install numpy==1.18 scipy==1.1.0 scikit-learn==0.21
 RUN echo '#!/bin/bash' >> entrypoint.sh
 RUN echo '/var/lib/milvus/bin/milvus_server -d -c /var/lib/milvus/conf/server_config.yaml -l /var/lib/milvus/conf/log_config.conf' >> entrypoint.sh
 RUN echo 'sleep 5' >> entrypoint.sh
-RUN echo 'python3 run_algorithm.py "$@"' >> entrypoint.sh
+RUN echo 'python3 -u run_algorithm.py "$@"' >> entrypoint.sh
 RUN chmod u+x entrypoint.sh
 ENTRYPOINT ["/home/app/entrypoint.sh"]

--- a/install/Dockerfile.vespa
+++ b/install/Dockerfile.vespa
@@ -14,4 +14,4 @@ COPY requirements.txt run_algorithm.py ./
 RUN python3 -m pip install -r requirements.txt && \
     python3 -m pip install /opt/vespa/libexec/vespa_ann_benchmark
 
-ENTRYPOINT ["python3", "run_algorithm.py"]
+ENTRYPOINT ["python3", "-u", "run_algorithm.py"]


### PR DESCRIPTION
I noticed on some setups that I don't get any output from the docker containers, basically until they are finished. Forcing `stdout` to be unbuffered fixes that.