### PR TITLE
Use faiss build from anaconda

### DIFF
--- a/install/Dockerfile.faiss
+++ b/install/Dockerfile.faiss
@@ -1,9 +1,20 @@
 FROM ann-benchmarks
 
-RUN apt-get update && apt-get install -y libopenblas-base libopenblas-dev libpython3-dev swig python3-dev libssl-dev wget
-RUN wget https://github.com/Kitware/CMake/releases/download/v3.18.3/cmake-3.18.3-Linux-x86_64.sh && mkdir cmake && sh cmake-3.18.3-Linux-x86_64.sh --skip-license --prefix=cmake && rm cmake-3.18.3-Linux-x86_64.sh
-RUN git clone https://github.com/facebookresearch/faiss lib-faiss
-RUN cd lib-faiss && ../cmake/bin/cmake -DFAISS_OPT_LEVEL=avx2 -DCMAKE_BUILD_TYPE=Release -DFAISS_ENABLE_GPU=OFF -DPython_EXECUTABLE=/usr/bin/python3 -B build .
-RUN cd lib-faiss && make -C build -j4
-RUN cd lib-faiss && cd build && cd faiss && cd python && python3 setup.py install && cd && rm -rf cmake
+RUN apt update && apt install -y wget
+RUN wget https://repo.anaconda.com/archive/Anaconda3-2020.11-Linux-x86_64.sh
+RUN bash Anaconda3-2020.11-Linux-x86_64.sh -b
+
+ENV PATH /root/anaconda3/bin:$PATH
+
+RUN conda install -c pytorch faiss-cpu
+COPY requirements_py38.txt ./
+# conda doesn't like some of our packages, use pip
+RUN python3 -m pip install -r requirements_py38.txt
+
+# https://developpaper.com/a-pit-of-mkl-library-in-linux-anaconda/
+ENV LD_PRELOAD /root/anaconda3/lib/libmkl_core.so:/root/anaconda3/lib/libmkl_sequential.so 
+
 RUN python3 -c 'import faiss; print(faiss.IndexFlatL2)'
+
+
+

--- a/requirements_py38.txt
+++ b/requirements_py38.txt
@@ -1,0 +1,11 @@
+ansicolors==1.1.8
+docker==5.0.2
+h5py==2.10.0
+matplotlib==3.3.4
+numpy==1.19.5
+pyyaml==5.3.1
+psutil==5.6.6
+scipy==1.5.4
+scikit-learn
+jinja2==2.10.1
+pandas==1.1.5


### PR DESCRIPTION
This uses the conda version of faiss (after I couldn't figure out why the old build failed). Probably helps faiss because it uses intel mkl instead of openblas. 