### PR TITLE
Replcing build from source build method with pip install for scann

### DIFF
--- a/install/Dockerfile.scann
+++ b/install/Dockerfile.scann
@@ -1,18 +1,5 @@
 FROM ann-benchmarks
 
-RUN apt-get install -y software-properties-common curl gnupg rsync
-
-RUN curl https://bazel.build/bazel-release.pub.gpg | apt-key add -
-RUN echo "deb [arch=amd64] https://storage.googleapis.com/bazel-apt stable jdk1.8" | tee /etc/apt/sources.list.d/bazel.list
-RUN apt-get update && apt-get install -y bazel-3.4.1
-
-RUN add-apt-repository -y ppa:ubuntu-toolchain-r/test
-RUN apt-get update
-RUN apt-get install -y g++-9 clang-8
-
 RUN pip3 install --upgrade pip
-RUN git clone https://github.com/google-research/google-research.git --depth=1
-RUN cd google-research/scann && python3 configure.py
-RUN PY3="$(which python3)" && cd google-research/scann && PYTHON_BIN_PATH=$PY3 CC=clang-8 bazel-3.4.1 build -c opt --features=thin_lto --copt=-mavx2 --copt=-mfma --cxxopt="-D_GLIBCXX_USE_CXX11_ABI=0" --cxxopt="-std=c++17" --copt=-fsized-deallocation --copt=-w :build_pip_pkg
-RUN cd google-research/scann && PYTHON=python3 ./bazel-bin/build_pip_pkg && pip3 install *.whl
+RUN pip3 install scann
 RUN python3 -c 'import scann'


### PR DESCRIPTION
Replcing build from source build method with pip install for scann. Current Dockerfile for Scann was building SCANN from source by building a whl file which can fail due to errors like =>

```
E: Failed to fetch https://storage.googleapis.com/bazel-apt/dists/stable/InRelease  403  Forbidden [IP: 199.36.153.4 443]
E: The repository 'https://storage.googleapis.com/bazel-apt stable InRelease' is not signed.
The command '/bin/sh -c apt-get update && apt-get install -y bazel-3.4.1' returned a non-zero code: 100
```

