### PR TITLE
Ubuntu 20.04 and default python

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         include:

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -72,8 +72,8 @@ jobs:
     steps:
     - uses: actions/checkout@v2 # Pull the repository
 
-    - name: Install HDF5 development support
-      run: sudo apt-get install -y libhdf5-serial-dev
+    - name: Install various apt packages
+      run: sudo apt-get install -y libhdf5-dev python3-numpy python3-scipy python3-matplotlib python3-sklearn
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -72,15 +72,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2 # Pull the repository
 
-    - name: Set up Python 3.6
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.6
-    
     - name: Install dependencies
       run: |
-        pip install -r requirements.txt
-        python install.py
+        pip3 install -r requirements.txt
+        python3 install.py
 
       env:
         LIBRARY: ${{ matrix.library }}
@@ -88,14 +83,14 @@ jobs:
     
     - name: Run the benchmark
       run: |
-        python run.py --docker-tag ann-benchmarks-${LIBRARY} --max-n-algorithms 5 --dataset $DATASET --run-disabled --timeout 300
-        python run.py --docker-tag ann-benchmarks-${LIBRARY} --max-n-algorithms 5 --dataset $DATASET --run-disabled --batch --timeout 300
+        python3 run.py --docker-tag ann-benchmarks-${LIBRARY} --max-n-algorithms 5 --dataset $DATASET --run-disabled --timeout 300
+        python3 run.py --docker-tag ann-benchmarks-${LIBRARY} --max-n-algorithms 5 --dataset $DATASET --run-disabled --batch --timeout 300
         sudo chmod -R 777 results/
-        python plot.py --dataset $DATASET --output plot.png
-        python plot.py --dataset $DATASET --output plot-batch.png --batch
-        python -m unittest test/test-metrics.py
-        python -m unittest test/test-jaccard.py
-        python create_website.py --outputdir . --scatter --latex
+        python3 plot.py --dataset $DATASET --output plot.png
+        python3 plot.py --dataset $DATASET --output plot-batch.png --batch
+        python3 -m unittest test/test-metrics.py
+        python3 -m unittest test/test-jaccard.py
+        python3 create_website.py --outputdir . --scatter --latex
 
       env:
         LIBRARY: ${{ matrix.library }}

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -72,6 +72,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2 # Pull the repository
 
+    - name: Install HDF5 development support
+      run: sudo apt-get install -y libhdf5-serial-dev
+
     - name: Install dependencies
       run: |
         pip3 install -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
-ansicolors
+ansicolors==1.1.8
 docker==5.0.2
-h5py
-matplotlib
-numpy
+h5py==2.10.0
+matplotlib==3.1.2
+numpy==1.17.4
 pyyaml==5.4
 psutil==5.6.6
-scipy
-scikit-learn
+scipy==1.3.3
+scikit-learn==0.22.2
 jinja2==2.10

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
-ansicolors==1.1.8
+ansicolors
 docker==5.0.2
-h5py==2.7.1
-matplotlib==2.1.0
-numpy==1.13.3
+h5py
+matplotlib
+numpy
 pyyaml==5.4
 psutil==5.6.6
-scipy==1.0.0
-scikit-learn==0.19.1
+scipy
+scikit-learn
 jinja2==2.10


### PR DESCRIPTION
In an attempt to simplify the installation, let's just use latest ubuntu (20.04) with the default version of Python (3.8)