### PR TITLE
Elastiknn: update to latest release, remove data scaling

### DIFF
--- a/algos.yaml
+++ b/algos.yaml
@@ -570,14 +570,14 @@ float:
       constructor: L2Lsh
       base-args: []
       run-groups:
-        elastiknn-lsh:
+        elastiknn-l2lsh:
           args:
-          - [50, 75, 100]
-          - [3, 4]
-          - [1, 3, 7]
+          - [100]         # L
+          - [4]           # k
+          - [1024, 2048]  # w
           query-args:
-          - [1000, 10000]
-          - [0, 6]
+          - [500, 1000]   # candidates
+          - [0, 3]        # probes
     opensearchknn:
       docker-tag: ann-benchmarks-opensearchknn
       module: ann_benchmarks.algorithms.opensearchknn

--- a/install/Dockerfile.elastiknn
+++ b/install/Dockerfile.elastiknn
@@ -5,16 +5,19 @@ WORKDIR /home/app
 # Install elasticsearch.
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt install -y wget curl htop
-RUN wget --quiet https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-oss-7.9.2-amd64.deb \
-    && dpkg -i elasticsearch-oss-7.9.2-amd64.deb \
-    && rm elasticsearch-oss-7.9.2-amd64.deb
+RUN wget --quiet https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.17.5-amd64.deb \
+    && dpkg -i elasticsearch-7.17.5-amd64.deb \
+    && rm elasticsearch-7.17.5-amd64.deb
 
 # Install python client.
-RUN python3 -m pip install --upgrade elastiknn-client==0.1.0rc47
+# Using no-deps because scipy (1.7.0) is incompatible with the container version of Python (3.6).
+# Then we need to install the deps manually.
+RUN python3 -m pip install --no-deps elastiknn-client==7.17.5.0
+RUN python3 -m pip install elasticsearch==7.17.4 dataclasses-json==0.3.7 tqdm==4.61.1
 
 # Install plugin.
 RUN /usr/share/elasticsearch/bin/elasticsearch-plugin install --batch \
-    https://github.com/alexklibisz/elastiknn/releases/download/0.1.0-PRE47/elastiknn-0.1.0-PRE47_es7.9.2.zip
+    https://github.com/alexklibisz/elastiknn/releases/download/7.17.5.0/elastiknn-7.17.5.0.zip
 
 # Configure elasticsearch and JVM for single-node, single-core.
 RUN cp /etc/elasticsearch/jvm.options /etc/elasticsearch/jvm.options.bak
@@ -29,6 +32,8 @@ node.processors: 1\n\
 thread_pool.write.size: 1\n\
 thread_pool.search.size: 1\n\
 thread_pool.search.queue_size: 1\n\
+bootstrap.memory_lock: true\n\
+xpack.security.enabled: false\n\
 path.data: /var/lib/elasticsearch\n\
 path.logs: /var/log/elasticsearch\n\
 ' > /etc/elasticsearch/elasticsearch.yml
@@ -52,9 +57,6 @@ RUN echo '\
 
 # JMX port. Need to also map the port when running.
 EXPOSE 8097
-
-# Make sure you can start the service.
-RUN service elasticsearch start && service elasticsearch stop
 
 # Custom entrypoint that also starts the Elasticsearch server.\
 RUN echo 'service elasticsearch start && python3 -u run_algorithm.py "$@"' > entrypoint.sh


### PR DESCRIPTION
Bumps Elastiknn versions to the latest.

Modifies algo parameters such that we can remove a data scaling step which was previously required in order to get decent results. The main difference is the width param, w: we set it higher to accommodate for the scale of the vector values, instead of scaling the vectors to accommodate for the w param.

New results should be on-par or better for Fashion MNIST. I haven't tested thoroughly with SIFT yet. I'll run some more tests this week on my own hardware and follow-up with another PR if necessary. Even if the params don't work well for SIFT, the algo will early-stop if throughput is < 50 qps after 500 queries.

New results running on my Dell XPS w/ i7-8750H CPU @ 2.20GHz. 

![plot](https://user-images.githubusercontent.com/8015228/179419907-ab24e188-f07d-4ddb-8190-3d785d8daf54.png)
