### PR TITLE
Switch to CentOS Stream 8 as OS for vespa container.

### DIFF
--- a/install/Dockerfile.vespa
+++ b/install/Dockerfile.vespa
@@ -1,11 +1,10 @@
-FROM centos:7
+FROM quay.io/centos/centos:stream8
 
-RUN yum -y install epel-release && \
-    yum -y install centos-release-scl && \
-    yum -y --setopt=skip_missing_names_on_install=False install gcc make git python3-devel && \
+RUN dnf -y install epel-release && \
+    dnf -y install gcc make git python3-devel && \
     python3 -m pip install --upgrade pip setuptools wheel && \
-    yum-config-manager --add-repo https://copr.fedorainfracloud.org/coprs/g/vespa/vespa/repo/epel-7/group_vespa-vespa-epel-7.repo && \
-    yum -y --setopt=skip_missing_names_on_install=False --enablerepo=epel-testing install vespa-ann-benchmark
+    dnf -y copr enable @vespa/vespa centos-stream-8 && \
+    dnf -y install vespa-ann-benchmark
 
 WORKDIR /home/app
 


### PR DESCRIPTION
With [Vespa 8](https://blog.vespa.ai/vespa-8-is-here/), the [supported OS has changed from CentOS 7 to CentOS Stream 8](https://blog.vespa.ai/Upcoming-changes-in-OS-support-for-Vespa/).
