### PR TITLE
Introduce custom exception type to recover from query errors

### DIFF
--- a/ann_benchmarks/algorithms/base.py
+++ b/ann_benchmarks/algorithms/base.py
@@ -17,6 +17,10 @@ class BaseANN(object):
         pass
 
     def query(self, q, n):
+        """
+        Run a a single query and return the array of candidate indices.
+        If the query fails in a recoverable fashion, raise a BaseANNQueryException.
+        """
         return []  # array of candidate indices
 
     def batch_query(self, X, n):
@@ -34,3 +38,6 @@ class BaseANN(object):
 
     def __str__(self):
         return self.name
+
+class BaseANNQueryException(Exception):
+    pass

--- a/ann_benchmarks/algorithms/elastiknn.py
+++ b/ann_benchmarks/algorithms/elastiknn.py
@@ -11,7 +11,7 @@ import numpy as np
 from elastiknn.api import Vec
 from elastiknn.models import ElastiknnModel
 
-from ann_benchmarks.algorithms.base import BaseANN
+from ann_benchmarks.algorithms.base import BaseANN, BaseANNQueryException
 
 from urllib.request import Request, urlopen
 from time import sleep, perf_counter
@@ -122,9 +122,9 @@ class L2Lsh(BaseANN):
         self.sum_query_dur += dur
         self.num_queries += 1
         if self.num_queries > 500 and self.num_queries / self.sum_query_dur < 50:
-            raise Exception("Throughput after 500 queries is less than 50 q/s. Giving up to avoid wasteful computation.")
+            raise BaseANNQueryException("Throughput after 500 queries is less than 50 q/s. Giving up to avoid wasteful computation.")
         elif res[-2:].sum() < 0:
-            raise Exception(f"Model returned fewer than {n} neighbors. Giving up to avoid wasteful computation.")
+            raise BaseANNQueryException(f"Model returned fewer than {n} neighbors. Giving up to avoid wasteful computation.")
         else:
             return res
 


### PR DESCRIPTION
This adds a way to let an algo early-stop a set of query parameters that are not going well (or
The query method can throw a BaseANNQueryException, and the `run` method will move onto the next set of query params (instead of killing the entire run).
