### PR TITLE
Upgrade to Ubuntu 22.04 and Python 3.10

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -9,7 +9,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 30
     strategy:
       matrix:

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ glove-25-angular
 Install
 =======
 
-The only prerequisite is Python (tested with 3.8) and Docker.
+The only prerequisite is Python (tested with 3.10.6) and Docker.
 
 1. Clone the repo.
 2. Run `pip install -r requirements.txt`.

--- a/install/Dockerfile
+++ b/install/Dockerfile
@@ -1,9 +1,9 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 RUN apt-get update
 RUN apt-get install -y python3-numpy python3-scipy python3-pip build-essential git
 RUN pip3 install -U pip
-RUN python3 --version | grep 'Python 3.8.10'
+RUN python3 --version | grep 'Python 3.10.6'
 
 WORKDIR /home/app
 COPY requirements.txt run_algorithm.py ./

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,9 +2,9 @@ ansicolors==1.1.8
 docker==6.0.1
 h5py==3.8.0
 matplotlib==3.6.3
-numpy==1.19.0
+numpy==1.21.5
 pyyaml==6.0
 psutil==5.9.4
-scipy==1.3.3
+scipy==1.8.0
 scikit-learn==1.2.1
 jinja2==3.1.2


### PR DESCRIPTION
Re #316 

* Upgrade the base Docker container to Ubuntu 22.04
* This automatically upgrades Python to 3.10.6
* Upgrade all packages in requirements.txt to their latest versions. I basically just pip-installed them one by one and pegged the requirements file to the version that was installed. 