### PR TITLE
Improvements to CI workflow

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -2,10 +2,15 @@ name: ANN benchmarks
 
 on: [push, pull_request]
 
+# Cancel the workflow for the previous commit when the new commit is pushed.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: True
+
 jobs:
   build:
-
     runs-on: ubuntu-20.04
+    timeout-minutes: 30
     strategy:
       matrix:
         include:
@@ -77,20 +82,21 @@ jobs:
             dataset: random-xs-20-angular
       fail-fast: false
 
+    env:
+      LIBRARY: ${{ matrix.library }}
+      DATASET: ${{ matrix.dataset }}
+
     steps:
     - uses: actions/checkout@v2 # Pull the repository
 
-    - name: Install various apt packages
+    - name: Install OS Dependencies
       run: sudo apt-get install -y libhdf5-dev python3-numpy python3-scipy python3-matplotlib python3-sklearn
 
-    - name: Install dependencies
-      run: |
-        pip3 install -r requirements.txt
-        python3 install.py
+    - name: Install Project Dependencies
+      run: pip3 install --quiet -r requirements.txt
 
-      env:
-        LIBRARY: ${{ matrix.library }}
-        DATASET: ${{ matrix.dataset }}
+    - name: Build Library Docker Image
+      run: python3 install.py
     
     - name: Run the benchmark
       run: |
@@ -103,7 +109,3 @@ jobs:
         python3 -m unittest test/test-metrics.py
         python3 -m unittest test/test-jaccard.py
         python3 create_website.py --outputdir . --scatter --latex
-
-      env:
-        LIBRARY: ${{ matrix.library }}
-        DATASET: ${{ matrix.dataset }}

--- a/install.py
+++ b/install.py
@@ -1,4 +1,4 @@
-import json
+import sys
 import os
 import argparse
 import subprocess
@@ -68,3 +68,9 @@ if __name__ == "__main__":
         pool.join()
 
     print('\n\nInstall Status:\n' + '\n'.join(str(algo) for algo in install_status))
+
+    # Exit 1 if any of the installations fail.
+    for x in install_status:
+        for (k,v) in x.items():
+            if v == 'fail':
+                sys.exit(1)


### PR DESCRIPTION
* Split the "install dependencies" step to two steps: 1) install project dependencies, 2) build the library image.
* Run `pip install` with `--quiet` to limit logging for faster CI debugging.
* Make install.py return 1 if the installation fails. Without this, the CI failures are misleading: install step succeeds even though install failed, then the run step fails w/ a confusing "nothing to run" error.
* Dedup the env vars in the CI workflow. We can have one env block for the full job, rather than the same env vars per step.
* Add concurrency settings to the CI workflow to cancel the workflow for the previous commit when a new commit is pushed.
* Add a timeout-minutes set to 20 to prevent runaway workflows, like the one here: https://github.com/erikbern/ann-benchmarks/pull/328#issuecomment-1408026679
