### PR TITLE
Enable powertools repo when installing vespa-ann-benchmark package.

### DIFF
--- a/install/Dockerfile.vespa
+++ b/install/Dockerfile.vespa
@@ -4,7 +4,7 @@ RUN dnf -y install epel-release && \
     dnf -y install gcc make git python3-devel && \
     python3 -m pip install --upgrade pip setuptools wheel && \
     dnf -y copr enable @vespa/vespa centos-stream-8 && \
-    dnf -y install vespa-ann-benchmark
+    dnf -y install --enablerepo=powertools vespa-ann-benchmark
 
 WORKDIR /home/app
 


### PR DESCRIPTION
This tracks move of xxhash-libs package to the powertools repo which is disabled by default.




