### PR TITLE
Upgrade elastiknn to 8.6.2.0

### DIFF
--- a/ann_benchmarks/algorithms/elastiknn.py
+++ b/ann_benchmarks/algorithms/elastiknn.py
@@ -26,11 +26,11 @@ logging.getLogger("elasticsearch").setLevel(logging.WARN)
 def es_wait():
     print("Waiting for elasticsearch health endpoint...")
     req = Request("http://localhost:9200/_cluster/health?wait_for_status=yellow&timeout=1s")
-    for i in range(30):
+    for i in range(60):
         try:
             res = urlopen(req)
             if res.getcode() == 200:
-                print("Elasticsearch is ready")
+                print(f"Elasticsearch is ready: {res.read().decode()}")
                 return
         except URLError:
             pass

--- a/install/Dockerfile.elastiknn
+++ b/install/Dockerfile.elastiknn
@@ -1,42 +1,50 @@
 FROM ann-benchmarks
 
+# Install curl.
+ENV DEBIAN_FRONTEND noninteractive
+RUN apt install -y curl
+
+# Create an app user, as elasticsearch cannot run as root.
+RUN mkdir -p /home/app
+RUN groupadd app
+RUN useradd app -g app -p app
+RUN chown -R app:app /home/app
 WORKDIR /home/app
+USER app
 
 # Install elasticsearch.
-ENV DEBIAN_FRONTEND noninteractive
-RUN apt install -y wget curl htop
-RUN wget --quiet https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.17.5-amd64.deb \
-    && dpkg -i elasticsearch-7.17.5-amd64.deb \
-    && rm elasticsearch-7.17.5-amd64.deb
+RUN curl -o elasticsearch.tar.gz https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-8.6.2-linux-x86_64.tar.gz
+RUN tar xzf elasticsearch.tar.gz
+RUN mv elasticsearch-* elasticsearch && rm elasticsearch.tar.gz
 
 # Install python client.
 # Using no-deps because scipy (1.7.0) is incompatible with the container version of Python (3.6).
 # Then we need to install the deps manually.
-RUN python3 -m pip install --no-deps elastiknn-client==7.17.5.0
-RUN python3 -m pip install elasticsearch==7.17.4 dataclasses-json==0.3.7 tqdm==4.61.1
+RUN python3 -m pip install --no-deps elastiknn-client==8.6.2.0
+RUN python3 -m pip install elasticsearch==8.6.1 dataclasses-json==0.3.7 tqdm==4.61.1
 
 # Install plugin.
-RUN /usr/share/elasticsearch/bin/elasticsearch-plugin install --batch \
-    https://github.com/alexklibisz/elastiknn/releases/download/7.17.5.0/elastiknn-7.17.5.0.zip
+RUN ./elasticsearch/bin/elasticsearch-plugin install --batch \
+    https://github.com/alexklibisz/elastiknn/releases/download/8.6.2.0/elastiknn-8.6.2.0.zip
+
+# Configuration
+# Backup the original configurations, which can be useful for comparing.
+RUN cp elasticsearch/config/jvm.options elasticsearch/config/jvm.options.bak
+RUN cp elasticsearch/config/elasticsearch.yml elasticsearch/config/elasticsearch.yml.bak
 
 # Configure elasticsearch and JVM for single-node, single-core.
-RUN cp /etc/elasticsearch/jvm.options /etc/elasticsearch/jvm.options.bak
-RUN cp /etc/elasticsearch/elasticsearch.yml /etc/elasticsearch/elasticsearch.yml.bak
-
 RUN echo '\
-discovery.type: single-node\n\
-network.host: 0.0.0.0\n\
-node.master: true\n\
-node.data: true\n\
+cluster.initial_master_nodes: main\n\
+node.name: main\n\
+node.roles: [master,data]\n\
 node.processors: 1\n\
+path.data: /home/app/elasticsearch/data\n\
+path.logs: /home/app/elasticsearch/logs\n\
 thread_pool.write.size: 1\n\
 thread_pool.search.size: 1\n\
 thread_pool.search.queue_size: 1\n\
-bootstrap.memory_lock: true\n\
 xpack.security.enabled: false\n\
-path.data: /var/lib/elasticsearch\n\
-path.logs: /var/log/elasticsearch\n\
-' > /etc/elasticsearch/elasticsearch.yml
+' > elasticsearch/config/elasticsearch.yml
 
 RUN echo '\
 -Xms3G\n\
@@ -45,19 +53,23 @@ RUN echo '\
 -XX:G1ReservePercent=25\n\
 -XX:InitiatingHeapOccupancyPercent=30\n\
 -XX:+HeapDumpOnOutOfMemoryError\n\
--XX:HeapDumpPath=/var/lib/elasticsearch\n\
--XX:ErrorFile=/var/log/elasticsearch/hs_err_pid%p.log\n\
--Xlog:gc*,gc+age=trace,safepoint:file=/var/log/elasticsearch/gc.log:utctime,pid,tags:filecount=32,filesize=64m\n\
+-XX:HeapDumpPath=/home/app/elasticsearch/logs\n\
+-XX:ErrorFile=/home/app/elasticsearch/logs/hs_err_pid%p.log\n\
+-Xlog:gc*,gc+age=trace,safepoint:file=/home/app/elasticsearch/logs/gc.log:utctime,pid,tags:filecount=32,filesize=64m\n\
 -Dcom.sun.management.jmxremote.ssl=false\n\
 -Dcom.sun.management.jmxremote.authenticate=false\n\
 -Dcom.sun.management.jmxremote.local.only=false\n\
 -Dcom.sun.management.jmxremote.port=8097\n\
 -Dcom.sun.management.jmxremote.rmi.port=8097\n\
--Djava.rmi.server.hostname=localhost' > /etc/elasticsearch/jvm.options
+-Djava.rmi.server.hostname=localhost' > elasticsearch/config/jvm.options
 
 # JMX port. Need to also map the port when running.
 EXPOSE 8097
 
-# Custom entrypoint that also starts the Elasticsearch server.\
-RUN echo 'service elasticsearch start && python3 -u run_algorithm.py "$@"' > entrypoint.sh
+# Custom entrypoint that also starts the Elasticsearch server in the background
+RUN echo '\
+set -e\n\
+nohup /home/app/elasticsearch/bin/elasticsearch > nohup.out &\n\
+python3 -u run_algorithm.py "$@" || (cat nohup.out && exit 1)\n\
+' > entrypoint.sh
 ENTRYPOINT ["/bin/bash", "/home/app/entrypoint.sh"]

--- a/install/Dockerfile.elastiknn
+++ b/install/Dockerfile.elastiknn
@@ -5,26 +5,20 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN apt install -y curl
 
 # Create an app user, as elasticsearch cannot run as root.
-RUN mkdir -p /home/app
-RUN groupadd app
-RUN useradd app -g app -p app
-RUN chown -R app:app /home/app
-WORKDIR /home/app
-USER app
+RUN mkdir -p /home/elasticsearch
+RUN groupadd elasticsearch
+RUN useradd elasticsearch -g elasticsearch -p elasticsearch
+RUN chown -R elasticsearch:elasticsearch /home/elasticsearch
+WORKDIR /home/elasticsearch
+USER elasticsearch
 
 # Install elasticsearch.
 RUN curl -o elasticsearch.tar.gz https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-8.6.2-linux-x86_64.tar.gz
 RUN tar xzf elasticsearch.tar.gz
 RUN mv elasticsearch-* elasticsearch && rm elasticsearch.tar.gz
 
-# Install python client.
-# Using no-deps because scipy (1.7.0) is incompatible with the container version of Python (3.6).
-# Then we need to install the deps manually.
-RUN python3 -m pip install --no-deps elastiknn-client==8.6.2.0
-RUN python3 -m pip install elasticsearch==8.6.1 dataclasses-json==0.3.7 tqdm==4.61.1
-
 # Install plugin.
-RUN ./elasticsearch/bin/elasticsearch-plugin install --batch \
+RUN /home/elasticsearch/elasticsearch/bin/elasticsearch-plugin install --batch \
     https://github.com/alexklibisz/elastiknn/releases/download/8.6.2.0/elastiknn-8.6.2.0.zip
 
 # Configuration
@@ -38,8 +32,8 @@ cluster.initial_master_nodes: main\n\
 node.name: main\n\
 node.roles: [master,data]\n\
 node.processors: 1\n\
-path.data: /home/app/elasticsearch/data\n\
-path.logs: /home/app/elasticsearch/logs\n\
+path.data: /home/elasticsearch/elasticsearch/data\n\
+path.logs: /home/elasticsearch/elasticsearch/logs\n\
 thread_pool.write.size: 1\n\
 thread_pool.search.size: 1\n\
 thread_pool.search.queue_size: 1\n\
@@ -53,9 +47,9 @@ RUN echo '\
 -XX:G1ReservePercent=25\n\
 -XX:InitiatingHeapOccupancyPercent=30\n\
 -XX:+HeapDumpOnOutOfMemoryError\n\
--XX:HeapDumpPath=/home/app/elasticsearch/logs\n\
--XX:ErrorFile=/home/app/elasticsearch/logs/hs_err_pid%p.log\n\
--Xlog:gc*,gc+age=trace,safepoint:file=/home/app/elasticsearch/logs/gc.log:utctime,pid,tags:filecount=32,filesize=64m\n\
+-XX:HeapDumpPath=/home/elasticsearch/elasticsearch/logs\n\
+-XX:ErrorFile=/home/elasticsearch/elasticsearch/logs/hs_err_pid%p.log\n\
+-Xlog:gc*,gc+age=trace,safepoint:file=/home/elasticsearch/elasticsearch/logs/gc.log:utctime,pid,tags:filecount=32,filesize=64m\n\
 -Dcom.sun.management.jmxremote.ssl=false\n\
 -Dcom.sun.management.jmxremote.authenticate=false\n\
 -Dcom.sun.management.jmxremote.local.only=false\n\
@@ -63,13 +57,24 @@ RUN echo '\
 -Dcom.sun.management.jmxremote.rmi.port=8097\n\
 -Djava.rmi.server.hostname=localhost' > elasticsearch/config/jvm.options
 
+
 # JMX port. Need to also map the port when running.
 EXPOSE 8097
+
+# Switch back to root because that's what CI expects.
+USER root
+WORKDIR /home/app
+
+# Install python client.
+# Using no-deps because scipy (1.7.0) is incompatible with the container version of Python (3.6).
+# Then we need to install the deps manually.
+RUN python3 -m pip install --no-deps elastiknn-client==8.6.2.0
+RUN python3 -m pip install elasticsearch==8.6.2 dataclasses-json==0.3.7 tqdm==4.61.1
 
 # Custom entrypoint that also starts the Elasticsearch server in the background
 RUN echo '\
 set -e\n\
-nohup /home/app/elasticsearch/bin/elasticsearch > nohup.out &\n\
+su - elasticsearch -c "nohup /home/elasticsearch/elasticsearch/bin/elasticsearch > nohup.out &"\n\
 python3 -u run_algorithm.py "$@" || (cat nohup.out && exit 1)\n\
-' > entrypoint.sh
+' > /home/app/entrypoint.sh
 ENTRYPOINT ["/bin/bash", "/home/app/entrypoint.sh"]


### PR DESCRIPTION
Upgrading elastiknn to the latest version 8.6.2.0.

I had to change the Elasticsearch installation to just use a tar download instead of using apt and deb files. This let me avoid systemd and sysctl, which I couldn't get working with the latest versions of Elasticsearch (even on newer ubuntu containers).

I still have to do a bit of gymnastics to get the python client installed. This should be resolved by upgrading to newer Python.

I had to increase the time spent waiting for Elasticsearch's to become available. It seems to take longer to initialize on 8.x versions compared to 7.x
