### PR TITLE
Use Python 3.9 on CentOS Stream 8.

### DIFF
--- a/install/Dockerfile.vespa
+++ b/install/Dockerfile.vespa
@@ -1,8 +1,13 @@
 FROM quay.io/centos/centos:stream8
 
 RUN dnf -y install epel-release && \
-    dnf -y install gcc make git python3-devel && \
-    python3 -m pip install --upgrade pip setuptools wheel && \
+    dnf -y install \
+        gcc \
+        make \
+        git \
+        python39-devel \
+        python39-pip \
+        python39-setuptools && \
     dnf -y copr enable @vespa/vespa centos-stream-8 && \
     dnf -y install --enablerepo=powertools vespa-ann-benchmark
 
@@ -10,7 +15,7 @@ WORKDIR /home/app
 
 COPY requirements.txt run_algorithm.py ./
 
-RUN python3 -m pip install -r requirements.txt && \
-    python3 -m pip install /opt/vespa/libexec/vespa_ann_benchmark
+RUN python3.9 -m pip install -r requirements.txt && \
+    python3.9 -m pip install /opt/vespa/libexec/vespa_ann_benchmark
 
-ENTRYPOINT ["python3", "-u", "run_algorithm.py"]
+ENTRYPOINT ["python3.9", "-u", "run_algorithm.py"]


### PR DESCRIPTION
The required python packages cannot be installed when using default python3 on CentOS Stream 8 (Python 3.6.8) but they
can be installed when using Python 3.9.16.
