### PR TITLE
Update Dockerfile.milvus

### DIFF
--- a/install/Dockerfile.milvus
+++ b/install/Dockerfile.milvus
@@ -1,7 +1,7 @@
 FROM milvusdb/knowhere-env:pyknowhere1.3-20230303
 
 WORKDIR /home/app
-COPY requirements_py38.txt run_algorithm.py ./
+COPY run_algorithm.py ./
 #RUN pip3 install -r requirements_py38.txt
 
 # update python packages


### PR DESCRIPTION
Fix Dockerfile for milvus
`Step 3/5 : COPY requirements_py38.txt run_algorithm.py ./
COPY failed: file not found in build context or excluded by .dockerignore: stat requirements_py38.txt: file does not exist`