### PR TITLE
Update numpy and scipy to work with Python 3.11

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -82,7 +82,7 @@ jobs:
     - uses: actions/checkout@v2 # Pull the repository
 
     - name: Install OS Dependencies
-      run: sudo apt-get install -y libhdf5-dev python3-numpy python3-scipy python3-matplotlib python3-sklearn
+      run: sudo apt-get update && sudo apt-get install -y libhdf5-dev python3-numpy python3-scipy python3-matplotlib python3-sklearn
 
     - name: Install Project Dependencies
       run: pip3 install --quiet -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,9 +2,9 @@ ansicolors==1.1.8
 docker==6.0.1
 h5py==3.8.0
 matplotlib==3.6.3
-numpy==1.21.5
+numpy==1.24.2
 pyyaml==6.0
 psutil==5.9.4
-scipy==1.8.0
+scipy==1.10.1
 scikit-learn==1.2.1
 jinja2==3.1.2


### PR DESCRIPTION
Hi, thanks for this project!

This updates NumPy and SciPy to the latest version so `pip install -r requirements.txt` works with Python 3.11.