### PR TITLE
Install dnf-plugins-core to get dnf copr plugin.

### DIFF
--- a/install/Dockerfile.vespa
+++ b/install/Dockerfile.vespa
@@ -1,6 +1,7 @@
 FROM quay.io/centos/centos:stream8
 
 RUN dnf -y install epel-release && \
+    dnf -y install dnf-plugins-core && \
     dnf -y install \
         gcc \
         make \


### PR DESCRIPTION
Docker image for CentOS Stream 8 no longer includes dnf copr plugin.
