### PR TITLE
remove scipy dep

### DIFF
--- a/ann_benchmarks/distance.py
+++ b/ann_benchmarks/distance.py
@@ -1,10 +1,6 @@
 from __future__ import absolute_import
-from scipy.spatial.distance import pdist as scipy_pdist
 import itertools
 import numpy as np
-
-def pdist(a, b, metric):
-    return scipy_pdist([a, b], metric=metric)[0]
 
 # Need own implementation of jaccard because scipy's
 # implementation is different
@@ -15,24 +11,29 @@ def jaccard(a, b):
     intersect = len(set(a) & set(b))
     return intersect / (float)(len(a) + len(b) - intersect)
 
+def norm(a):
+    return np.sum(a ** 2) ** 0.5
+
+def euclidean(a, b):
+    return norm(a - b)
+
 metrics = {
     'hamming': {
-        'distance': lambda a, b: pdist(a, b, "hamming"),
-        'distance_valid': lambda a: True
+        'distance': lambda a, b: np.sum(np.abs(a - b)),
+        'distance_valid': lambda a: True,
     },
     # return 1 - jaccard similarity, because smaller distances are better.
-    # modified to use pdist jaccard given new data format (boolean ndarray)
     'jaccard': {
-        'distance': lambda a, b: 1 - jaccard(a, b), #pdist(a, b, "jaccard"), 
-        'distance_valid': lambda a: a < 1 - 1e-5
+        'distance': lambda a, b: 1 - jaccard(a, b),
+        'distance_valid': lambda a: a < 1 - 1e-5,
     },
     'euclidean': {
-        'distance': lambda a, b: pdist(a, b, "euclidean"),
-        'distance_valid': lambda a: True
+        'distance': lambda a, b: euclidean(a, b),
+        'distance_valid': lambda a: True,
     },
     'angular': {
-        'distance': lambda a, b: pdist(a, b, "cosine"),
-        'distance_valid': lambda a: True
+        'distance': lambda a, b: euclidean(a, b) / (norm(a) * norm(b)),
+        'distance_valid': lambda a: True,
     }
 }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,5 @@ matplotlib==3.6.3
 numpy==1.24.2
 pyyaml==6.0
 psutil==5.9.4
-scipy==1.10.1
 scikit-learn==1.2.1
 jinja2==3.1.2

--- a/test/test-distance.py
+++ b/test/test-distance.py
@@ -1,0 +1,10 @@
+import unittest
+import numpy
+
+from ann_benchmarks.distance import euclidean
+
+class TestDistance(unittest.TestCase):
+    def test_euclidean(self):
+        p = numpy.array([0, 1, 0])
+        q = numpy.array([2, 0, 0])
+        self.assertAlmostEqual(euclidean(p, q), 5 ** 0.5)


### PR DESCRIPTION
wasn't able to install it on my mac, and it's basically not used anyway – it's very easy to just implement these distance metrics using numpy