### PR TITLE
Fix CI warning

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -79,7 +79,7 @@ jobs:
       DATASET: ${{ matrix.dataset }}
 
     steps:
-    - uses: actions/checkout@v2 # Pull the repository
+    - uses: actions/checkout@v3 # Pull the repository
 
     - name: Install OS Dependencies
       run: sudo apt-get install -y libhdf5-dev python3-numpy python3-scipy python3-matplotlib python3-sklearn


### PR DESCRIPTION
Minor PR to fix the following warning on CI:

"Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2"