### PR TITLE
pgvector improvements

### DIFF
--- a/algos.yaml
+++ b/algos.yaml
@@ -547,6 +547,7 @@ float:
       run-groups:
         pgvector:
           args: [[100, 200, 400, 1000, 2000, 4000, 10000]]
+          query-args: [[1, 2, 4, 10, 20, 40, 100]]
 
   euclidean:
     vamana(diskann):

--- a/install/Dockerfile.pgvector
+++ b/install/Dockerfile.pgvector
@@ -6,9 +6,10 @@ RUN git clone https://github.com/pgvector/pgvector /tmp/pgvector
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y install tzdata
 RUN apt-get install -y --no-install-recommends build-essential postgresql postgresql-server-dev-all
+RUN sh -c 'echo "local all all trust" > /etc/postgresql/14/main/pg_hba.conf'
 RUN cd /tmp/pgvector && \
 	make clean && \
-	make OPTFLAGS="" && \
+	make && \
 	make install
 
 USER postgres


### PR DESCRIPTION
Initial round of improvements for pgvector:

1. Set `ivfflat.probes` to improve recall
2. Remove `OPTFLAGS=""` so it's compiled with `-march=native` (which enables additional SIMD instructions on supported platforms)
3. Use Unix-domain socket (rather than networking stack)
4. Use binary serialization (to reduce serialization overhead)
5. Use prepared statements (to reduce statement parsing overhead)
6. Increase `work_mem` (to allow for more memory usage)