### PR TITLE
Partial fix for SPTAG build

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -15,7 +15,7 @@ jobs:
   unit-tests:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2 # Pull the repository
+      - uses: actions/checkout@v3 # Pull the repository
       - run: sudo apt-get update && sudo apt-get install -y libhdf5-dev python3-numpy python3-scipy python3-matplotlib python3-sklearn
       - run: pip3 install --quiet -r requirements.txt
       - run: pytest

--- a/install/Dockerfile.sptag
+++ b/install/Dockerfile.sptag
@@ -2,7 +2,7 @@
 
 FROM ann-benchmarks
 
-RUN git clone https://github.com/microsoft/SPTAG
+RUN git clone --recursive https://github.com/microsoft/SPTAG
 RUN apt-get update && apt-get -y install wget build-essential libtbb-dev software-properties-common swig
 
 # cmake >= 3.12 is required


### PR DESCRIPTION
SPTAG added a [Git submodule for `zstd`](https://github.com/microsoft/SPTAG/tree/0df1b75e6a75660c13d91b3663671a2159eaea96/ThirdParty), which causes the build to fail with the following error:

```text
CMake Error at CMakeLists.txt:121 (add_subdirectory):
  add_subdirectory given source "ThirdParty/zstd/build/cmake" which is not an
  existing directory.
```

This PR fixes that error, along with the remaining CI warning.

The build [still fails](https://github.com/ankane/ann-benchmarks/actions/runs/4660508942/jobs/8248650137) with a new error:

```text
In file included from /home/app/SPTAG/AnnService/inc/Core/Common/WorkSpacePool.h:8,
                 from /home/app/SPTAG/AnnService/inc/Core/BKT/Index.h:15,
                 from /home/app/SPTAG/AnnService/src/Core/BKT/BKTIndex.cpp:4:
/home/app/SPTAG/AnnService/inc/Helper/ConcurrentSet.h: In member function 'void SPTAG::Helper::Concurrent::ConcurrentSet<T>::insert(const T&)':
/home/app/SPTAG/AnnService/inc/Helper/ConcurrentSet.h:46:26: error: 'unique_lock' is not a member of 'std'
   46 |                     std::unique_lock<std::shared_timed_mutex> lock(*m_lock);
      |                          ^~~~~~~~~~~
/home/app/SPTAG/AnnService/inc/Helper/ConcurrentSet.h:12:1: note: 'std::unique_lock' is defined in header '<mutex>'; did you forget to '#include <mutex>'?
   11 | #include <queue>
  +++ |+#include <mutex>
```

which looks to be due to a missing include: https://github.com/microsoft/SPTAG/issues/243