### PR TITLE
Fix KeyError

### DIFF
--- a/ann_benchmarks/runner.py
+++ b/ann_benchmarks/runner.py
@@ -261,7 +261,7 @@ def run_docker(definition, dataset, count, runs, timeout, batch, cpu_limit, mem_
 def _handle_container_return_value(return_value, container, logger):
     base_msg = "Child process for container %s" % (container.short_id)
     if type(return_value) is dict:  # The return value from container.wait changes from int to dict in docker 3.0.0
-        error_msg = return_value["Error"]
+        error_msg = return_value.get("Error")
         exit_code = return_value["StatusCode"]
         msg = base_msg + "returned exit code %d with message %s" % (exit_code, error_msg)
     else:


### PR DESCRIPTION
With Docker 23 on Ubuntu 22.04, I'm seeing the following error:

```text
2023-04-10 20:00:28,118 - annb.330fe43cd51c - ERROR - Container.wait for container 330fe43cd51c failed with exception
Traceback (most recent call last):
  File "/tmp/ann-benchmarks/ann_benchmarks/runner.py", line 253, in run_docker
    _handle_container_return_value(return_value, container, logger)
  File "/tmp/ann-benchmarks/ann_benchmarks/runner.py", line 264, in _handle_container_return_value
    error_msg = return_value["Error"]
KeyError: 'Error'
```

It looks like `return_value` is `{'StatusCode': 0}` instead of `{'Error': None, 'StatusCode': 0}` (which I'm seeing with Docker 20 on Mac).