### PR TITLE
Fix Faiss CI failures

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -65,6 +65,9 @@ jobs:
     env:
       LIBRARY: ${{ matrix.library }}
       DATASET: ${{ matrix.dataset }}
+      RUN_OPTIONS: ${{ matrix.library != 'faiss' && '--run-disabled' || '' }}
+
+    name: ${{ matrix.library }} (${{ matrix.dataset }})
 
     steps:
     - uses: actions/checkout@v3 # Pull the repository
@@ -80,8 +83,8 @@ jobs:
     
     - name: Run the benchmark
       run: |
-        python3 run.py --docker-tag ann-benchmarks-${LIBRARY} --max-n-algorithms 3 --runs 2 --dataset $DATASET --run-disabled --timeout 300
-        python3 run.py --docker-tag ann-benchmarks-${LIBRARY} --max-n-algorithms 3 --runs 2 --dataset $DATASET --run-disabled --batch --timeout 300
+        python3 run.py --docker-tag ann-benchmarks-${LIBRARY} --max-n-algorithms 3 --runs 2 --dataset $DATASET $RUN_OPTIONS --timeout 300
+        python3 run.py --docker-tag ann-benchmarks-${LIBRARY} --max-n-algorithms 3 --runs 2 --dataset $DATASET $RUN_OPTIONS --batch --timeout 300
         sudo chmod -R 777 results/
         python3 plot.py --dataset $DATASET --output plot.png
         python3 plot.py --dataset $DATASET --output plot-batch.png --batch

--- a/install/Dockerfile.faiss
+++ b/install/Dockerfile.faiss
@@ -1,7 +1,7 @@
 FROM ann-benchmarks
 
 RUN apt update && apt install -y wget
-RUN wget https://repo.anaconda.com/archive/Anaconda3-2020.11-Linux-x86_64.sh
+RUN wget -q https://repo.anaconda.com/archive/Anaconda3-2020.11-Linux-x86_64.sh
 RUN bash Anaconda3-2020.11-Linux-x86_64.sh -b
 
 ENV PATH /root/anaconda3/bin:$PATH


### PR DESCRIPTION
CI currently fails when`faiss-gpu` is randomly selected to run (which is possible since CI uses `--run-disabled`).

```text
Trying to instantiate ann_benchmarks.algorithms.faiss_gpu.FaissGPU([4096, 1])
Traceback (most recent call last):
  File "run_algorithm.py", line 3, in <module>
    run_from_cmdline()
  File "/home/app/ann_benchmarks/runner.py", line 198, in run_from_cmdline
    run(definition, args.dataset, args.count, args.runs, args.batch)
  File "/home/app/ann_benchmarks/runner.py", line 101, in run
    algo = instantiate_algorithm(definition)
  File "/home/app/ann_benchmarks/algorithms/definitions.py", line 17, in instantiate_algorithm
    return constructor(*definition.arguments)
  File "/home/app/ann_benchmarks/algorithms/faiss_gpu.py", line 19, in __init__
    self._res = faiss.StandardGpuResources()
AttributeError: module 'faiss' has no attribute 'StandardGpuResources'
```

This fixes it, and incorporates two other changes (happy to split into separate PRs if desired):

1. Adds `-q` to reduce excessive `wget` output for Faiss build
2. Updates the job name on CI so it's easier to see what's running

Edit: Example failure - https://github.com/erikbern/ann-benchmarks/actions/runs/4662682480/jobs/8253299697