### PR TITLE
More query params for fast_pq

### DIFF
--- a/algos.yaml
+++ b/algos.yaml
@@ -215,7 +215,8 @@ float:
       run-groups:
         fast_pq:
           args: [[1, 2, 3]]
-          query-args: [[1, 2, 3, 4, 6, 8, 10, 13, 16, 20, 24, 28, 33, 38, 44, 50, 57, 64, 72, 80]]
+          query-args: [[1, 2, 3, 4, 6, 8, 10, 13, 16, 20, 24, 28, 33, 38, 44, 50, 57, 64, 72, 80,
+                        88, 106, 126, 148, 172, 198, 226, 256, 288, 321, 356, 393, 432, 473, 516]]
     Milvus(Knowhere):
       docker-tag: ann-benchmarks-milvus
       module: ann_benchmarks.algorithms.milvus

--- a/algos.yaml
+++ b/algos.yaml
@@ -216,7 +216,7 @@ float:
         fast_pq:
           args: [[1, 2, 3]]
           query-args: [[1, 2, 3, 4, 6, 8, 10, 13, 16, 20, 24, 28, 33, 38, 44, 50, 57, 64, 72, 80,
-                        88, 106, 126, 148, 172, 198, 226, 256, 288, 321, 356, 393, 432, 473, 516]]
+                        88, 106, 126, 148, 172, 198, 256]]
     Milvus(Knowhere):
       docker-tag: ann-benchmarks-milvus
       module: ann_benchmarks.algorithms.milvus


### PR DESCRIPTION
Fixed git issues.
New values don't grow exponentially, but fast than the first "tier".