### PR TITLE
Tweak OpenSearch Dockerfile to download architecture specific version

### DIFF
--- a/install/Dockerfile.opensearchknn
+++ b/install/Dockerfile.opensearchknn
@@ -5,19 +5,27 @@ FROM ann-benchmarks
 
 WORKDIR /home/app
 
-# Install Opensearch following instructions from https://opensearch.org/docs/opensearch/install/tar/
+# Install OpenSearch following instructions from https://opensearch.org/docs/opensearch/install/tar/
 # and https://opensearch.org/docs/opensearch/install/important-settings/
 RUN apt-get install tmux wget gosu -y
-RUN wget https://artifacts.opensearch.org/releases/bundle/opensearch/1.0.0/opensearch-1.0.0-linux-x64.tar.gz
-RUN tar -zxf opensearch-1.0.0-linux-x64.tar.gz
-RUN rm -r opensearch-1.0.0-linux-x64.tar.gz opensearch-1.0.0/plugins/opensearch-security
+
+RUN set -eux ; \
+    ARCH=''; \
+    case "$(arch)" in \
+        aarch64) ARCH='arm64' ;; \
+        x86_64)  ARCH='x64' ;; \
+        *) echo >&2 ; echo >&2 "Unsupported architecture $(arch)" ; echo >&2 ; exit 1 ;; \
+    esac ; \
+    wget https://artifacts.opensearch.org/releases/bundle/opensearch/1.0.0/opensearch-1.0.0-linux-$ARCH.tar.gz; \
+    tar -zxf opensearch-1.0.0-linux-$ARCH.tar.gz; \
+    rm -r opensearch-1.0.0-linux-$ARCH.tar.gz opensearch-1.0.0/plugins/opensearch-security;
+
 RUN chmod -R 777 opensearch-1.0.0
 RUN sysctl -w vm.max_map_count=262144
 
-# Install python client.
 RUN python3 -m pip install --upgrade elasticsearch==7.13.4 tqdm
 
-# Configure opensearch for single-node, single-core.
+# Configure OpenSearch for single-node, single-core.
 RUN echo '\
 discovery.type: single-node\n\
 network.host: 0.0.0.0\n\
@@ -36,8 +44,9 @@ RUN echo '\
 -XX:ErrorFile=logs/hs_err_pid%p.log\n\
 -Xlog:gc*,gc+age=trace,safepoint:file=logs/gc.log:utctime,pid,tags:filecount=32,filesize=64m' > opensearch-1.0.0/config/jvm.options
 
-# Custom entrypoint that also starts the Opensearch server
+# Custom entrypoint that also starts the OpenSearch server.
 RUN useradd -m opensearch
 RUN echo 'tmux new-session -d -s opensearch """exec gosu opensearch "./opensearch-1.0.0/opensearch-tar-install.sh""""' > entrypoint.sh
 RUN echo 'python3 -u run_algorithm.py "$@"' >> entrypoint.sh
+
 ENTRYPOINT ["/bin/bash", "/home/app/entrypoint.sh"]


### PR DESCRIPTION
It's currently not possible to run the OpenSearch KNN benchmark on arm64 (useful for local debugging and development).

Tweak the Dockerfile to download a architecture specific version of OpenSearch.