### PR TITLE
Bump OpenSearch KNN version

### DIFF
--- a/install/Dockerfile.opensearchknn
+++ b/install/Dockerfile.opensearchknn
@@ -35,7 +35,7 @@ RUN chmod -R 777 opensearch
 
 RUN echo "vm.max_map_count=262144" >> /etc/sysctl.conf
 
-RUN python3 -m pip install --upgrade elasticsearch==7.13.4 tqdm
+RUN python3 -m pip install --upgrade opensearch-py==2.2.0 tqdm
 
 # Configure OpenSearch for single-node, single-core.
 RUN echo '\


### PR DESCRIPTION
Bump OpenSearch to the latest stable version.

While here, switch out the [`elasticsearch-py`](https://github.com/elastic/elasticsearch-py) library with [`opensearch-py`](https://github.com/opensearch-project/opensearch-py) which is the official Python library for OpenSearch.