### PR TITLE
Add Elasticsearch KNN

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Evaluated
 * [PUFFINN](https://github.com/puffinn/puffinn) ![https://img.shields.io/github/stars/puffinn/puffinn?style=social](https://img.shields.io/github/stars/puffinn/puffinn?style=social)
 * [N2](https://github.com/kakao/n2) ![https://img.shields.io/github/stars/kakao/n2?style=social](https://img.shields.io/github/stars/kakao/n2?style=social)
 * [ScaNN](https://github.com/google-research/google-research/tree/master/scann)
+* [Elasticsearch](https://github.com/elastic/elasticsearch) ![https://img.shields.io/github/stars/elastic/elasticsearch?style=social](https://img.shields.io/github/stars/elastic/elasticsearch?style=social): HNSW
 * [Elastiknn](https://github.com/alexklibisz/elastiknn) ![https://img.shields.io/github/stars/alexklibisz/elastiknn?style=social](https://img.shields.io/github/stars/alexklibisz/elastiknn?style=social)
 * [OpenSearch KNN](https://github.com/opensearch-project/k-NN) ![https://img.shields.io/github/stars/opensearch-project/k-NN?style=social](https://img.shields.io/github/stars/opensearch-project/k-NN?style=social)
 * [DiskANN](https://github.com/microsoft/diskann) ![https://img.shields.io/github/stars/microsoft/diskann?style=social](https://img.shields.io/github/stars/microsoft/diskann?style=social): Vamana, Vamana-PQ

--- a/algos.yaml
+++ b/algos.yaml
@@ -824,11 +824,13 @@ float:
     elasticsearch:
       docker-tag: ann-benchmarks-elasticsearch
       module: ann_benchmarks.algorithms.elasticsearch
-      constructor: ElasticsearchScriptScoreQuery
-      base-args: [ "@metric", "@dimension" ]
+      constructor: ElasticsearchKNN
+      base-args: ["@metric", "@dimension"]
       run-groups:
-        empty:
-          args: []
+        m-16-ef-100:
+          arg-groups:
+            - {"m": 16,  "ef_construction": 100} # index_options
+          query-args: [[10, 20, 40, 80, 160]] # num_candidates
     elastiknn-l2lsh:
       docker-tag: ann-benchmarks-elastiknn
       module: ann_benchmarks.algorithms.elastiknn
@@ -1143,11 +1145,13 @@ float:
     elasticsearch:
       docker-tag: ann-benchmarks-elasticsearch
       module: ann_benchmarks.algorithms.elasticsearch
-      constructor: ElasticsearchScriptScoreQuery
-      base-args: [ "@metric", "@dimension" ]
+      constructor: ElasticsearchKNN
+      base-args: ["@metric", "@dimension"]
       run-groups:
-        empty:
-          args: []
+        m-16-ef-100:
+          arg-groups:
+            - {"m": 16,  "ef_construction": 100} # index_options
+          query-args: [[10, 20, 40, 80, 160]] # num_candidates
     opensearchknn:
       docker-tag: ann-benchmarks-opensearchknn
       module: ann_benchmarks.algorithms.opensearchknn

--- a/install/Dockerfile.elasticsearch
+++ b/install/Dockerfile.elasticsearch
@@ -1,45 +1,72 @@
-FROM ann-benchmarks
+FROM ann-benchmarks AS builder
+ARG ELASTICSEARCH_VERSION=8.7.0
 
-WORKDIR /home/app
-
-# Install elasticsearch.
 ENV DEBIAN_FRONTEND noninteractive
-RUN apt install -y wget curl htop
-RUN wget --quiet https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.9.2-amd64.deb \
-    && dpkg -i elasticsearch-7.9.2-amd64.deb \
-    && rm elasticsearch-7.9.2-amd64.deb
+RUN apt-get install -y curl
 
-# Install python client.
-RUN python3 -m pip install --upgrade elasticsearch==7.9.1
+# Download Elasticsearch to intermediate builder.
+WORKDIR /tmp
+RUN curl -OsS https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${ELASTICSEARCH_VERSION}-linux-$(arch).tar.gz
+RUN curl -sS https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${ELASTICSEARCH_VERSION}-linux-$(arch).tar.gz.sha512 | shasum -a 512 -c -
 
-# Configure elasticsearch and JVM for single-node, single-core.
+WORKDIR /usr/share/elasticsearch
+RUN tar -zxf /tmp/elasticsearch-${ELASTICSEARCH_VERSION}-linux-$(arch).tar.gz --strip-components=1
+
+# Install Elasticsearch in final image:
+#  - https://www.elastic.co/guide/en/elasticsearch/reference/current/targz.html
+#  - https://www.elastic.co/guide/en/elasticsearch/reference/current/system-config.html
+FROM ann-benchmarks
+ARG ELASTICSEARCH_VERSION=8.7.0
+
+ENV DEBIAN_FRONTEND noninteractive
+RUN apt-get install -y curl
+
+WORKDIR /usr/share/elasticsearch
+
+# Create elasticsearch user and user group.
+RUN groupadd -g 1000 elasticsearch
+RUN adduser --uid 1000 --gid 1000 --home /usr/share/elasticsearch elasticsearch
+
+COPY --from=builder --chown=elasticsearch:elasticsearch /usr/share/elasticsearch /usr/share/elasticsearch
+
+RUN echo "vm.max_map_count=262144" >> /etc/sysctl.conf
+
+# Backup original configurations for potential future reference.
+RUN cp config/elasticsearch.yml config/elasticsearch.yml.bak
+RUN cp config/jvm.options config/jvm.options.bak
+
+# Configure Elasticsearch for single-node, single-core.
 RUN echo '\
 discovery.type: single-node\n\
-network.host: 0.0.0.0\n\
-node.master: true\n\
-node.data: true\n\
+node.roles: [master, data]\n\
 node.processors: 1\n\
+path.data: /usr/share/elasticsearch/data\n\
+path.logs: /usr/share/elasticsearch/logs\n\
+bootstrap.memory_lock: true\n\
 thread_pool.write.size: 1\n\
 thread_pool.search.size: 1\n\
 thread_pool.search.queue_size: 1\n\
-path.data: /var/lib/elasticsearch\n\
-path.logs: /var/log/elasticsearch\n\
-' > /etc/elasticsearch/elasticsearch.yml
+xpack.security.enabled: false\n\
+' > config/elasticsearch.yml
 
 RUN echo '\
 -Xms3G\n\
 -Xmx3G\n\
 -XX:+UseG1GC\n\
--XX:G1ReservePercent=25\n\
--XX:InitiatingHeapOccupancyPercent=30\n\
--XX:+HeapDumpOnOutOfMemoryError\n\
--XX:HeapDumpPath=/var/lib/elasticsearch\n\
--XX:ErrorFile=/var/log/elasticsearch/hs_err_pid%p.log\n\
--Xlog:gc*,gc+age=trace,safepoint:file=/var/log/elasticsearch/gc.log:utctime,pid,tags:filecount=32,filesize=64m' > /etc/elasticsearch/jvm.options
+-XX:HeapDumpPath=data\n\
+-XX:ErrorFile=/usr/share/elasticsearch/logs/hs_err_pid%p.log\n\
+-Xlog:gc*,gc+age=trace,safepoint:file=/usr/share/elasticsearch/logs/gc.log:utctime,pid,tags:filecount=32,filesize=64m\n\
+' > config/jvm.options
 
-# Make sure you can start the service.
-RUN service elasticsearch start && service elasticsearch stop
+RUN chown -R elasticsearch:elasticsearch /usr/share/elasticsearch
+
+WORKDIR /home/app
+
+RUN python3 -m pip install elasticsearch==${ELASTICSEARCH_VERSION}
 
 # Custom entrypoint that also starts the Elasticsearch server.
-RUN echo 'service elasticsearch start && python3 -u run_algorithm.py "$@"' > entrypoint.sh
+RUN echo 'set -eux' >> entrypoint.sh
+RUN echo 'su - elasticsearch -c "nohup /usr/share/elasticsearch/bin/elasticsearch > nohup.out 2>&1 &"' >> entrypoint.sh
+RUN echo 'python3 -u run_algorithm.py "$@"' >> entrypoint.sh
+
 ENTRYPOINT ["/bin/bash", "/home/app/entrypoint.sh"]


### PR DESCRIPTION
Add an implementation for [Elasticsearch KNN search](https://www.elastic.co/guide/en/elasticsearch/reference/current/knn-search.html). Fixes https://github.com/erikbern/ann-benchmarks/issues/298.

 - Supports specifying [`index_options`](https://www.elastic.co/guide/en/elasticsearch/reference/8.7/dense-vector.html#dense-vector-params) via arg groups, with one entry for Elasticsearch's [default settings](https://www.elastic.co/guide/en/elasticsearch/reference/8.7/dense-vector.html#dense-vector-params) for M and EF.
 - Supports specifying [`num_candidates`](https://www.elastic.co/guide/en/elasticsearch/reference/8.7/knn-search-api.html#knn-search-api-request-body) via query args.

What do you think @erikbern, @alexklibisz?