### PR TITLE
Improve pgvector performance by ~2x

### DIFF
--- a/algos.yaml
+++ b/algos.yaml
@@ -546,7 +546,7 @@ float:
       base-args: ["@metric"]
       run-groups:
         pgvector:
-          args: [[100, 200, 400, 1000, 2000, 4000, 10000]]
+          args: [[100, 200, 400, 1000, 2000, 4000]]
           query-args: [[1, 2, 4, 10, 20, 40, 100]]
 
   euclidean:

--- a/ann_benchmarks/algorithms/pgvector.py
+++ b/ann_benchmarks/algorithms/pgvector.py
@@ -26,6 +26,7 @@ class PGVector(BaseANN):
         pgvector.psycopg.register_vector(conn)
         cur = conn.cursor()
         cur.execute("CREATE TABLE items (id int, embedding vector(%d))" % X.shape[1])
+        cur.execute("ALTER TABLE items ALTER COLUMN embedding SET STORAGE PLAIN")
         print("copying data...")
         with cur.copy("COPY items (id, embedding) FROM STDIN") as copy:
             for i, embedding in enumerate(X):
@@ -44,7 +45,7 @@ class PGVector(BaseANN):
 
     def set_query_arguments(self, probes):
         self._probes = probes
-        self._cur.execute("SET ivfflat.probes = '%d'" % probes)
+        self._cur.execute("SET ivfflat.probes = %d" % probes)
         # TODO set based on available memory
         self._cur.execute("SET work_mem = '256MB'")
         # disable parallel query execution

--- a/install/Dockerfile.pgvector
+++ b/install/Dockerfile.pgvector
@@ -5,11 +5,11 @@ FROM ann-benchmarks
 RUN git clone https://github.com/pgvector/pgvector /tmp/pgvector
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y install tzdata
-RUN apt-get install -y --no-install-recommends build-essential postgresql postgresql-server-dev-all
+RUN apt-get update && apt-get install -y --no-install-recommends build-essential postgresql postgresql-server-dev-all
 RUN sh -c 'echo "local all all trust" > /etc/postgresql/14/main/pg_hba.conf'
 RUN cd /tmp/pgvector && \
 	make clean && \
-	make && \
+	make OPTFLAGS="-march=native -mprefer-vector-width=512" && \
 	make install
 
 USER postgres
@@ -17,7 +17,7 @@ RUN service postgresql start && \
     psql -c "CREATE USER ann WITH ENCRYPTED PASSWORD 'ann'" && \
     psql -c "CREATE DATABASE ann" && \
     psql -c "GRANT ALL PRIVILEGES ON DATABASE ann TO ann" && \
-    psql -d ann -c "CREATE EXTENSION vector" && \ 
+    psql -d ann -c "CREATE EXTENSION vector" && \
     psql -c "ALTER USER ann SET maintenance_work_mem = '16GB'"
 USER root
 


### PR DESCRIPTION
Hi @erikbern, thanks for the updated benchmarks. Made two more improvements to pgvector:

1. Disabled compression and out-of-line storage
2. Set `-mprefer-vector-width=512`

Also, removed `lists = 10000` since it requires `maintenance_work_mem` to be higher.