### PR TITLE
Documentation, Typing and Refactors

### DIFF
--- a/ann_benchmarks/algorithms/base/module.py
+++ b/ann_benchmarks/algorithms/base/module.py
@@ -1,36 +1,79 @@
 from multiprocessing.pool import ThreadPool
-
+from typing import Any, Dict, Optional
 import psutil
 
+import numpy
 
 class BaseANN(object):
-    def done(self):
+    """Base class/interface for Approximate Nearest Neighbors (ANN) algorithms used in benchmarking."""
+
+    def done(self) -> None:
+        """Clean up BaseANN once it is finished being used."""
         pass
 
-    def get_memory_usage(self):
-        """Return the current memory usage of this algorithm instance
-        (in kilobytes), or None if this information is not available."""
-        # return in kB for backwards compatibility
+    def get_memory_usage(self) -> Optional[float]:
+        """Returns the current memory usage of this ANN algorithm instance in kilobytes.
+
+        Returns:
+            float: The current memory usage in kilobytes (for backwards compatibility), or None if
+                this information is not available.
+        """
+
         return psutil.Process().memory_info().rss / 1024
 
-    def fit(self, X):
+    def fit(self, X: numpy.array) -> None:
+        """Fits the ANN algorithm to the provided data. 
+
+        Note: This is a placeholder method to be implemented by subclasses.
+
+        Args:
+            X (numpy.array): The data to fit the algorithm to.
+        """
         pass
 
-    def query(self, q, n):
+    def query(self, q: numpy.array, n: int) -> numpy.array:
+        """Performs a query on the algorithm to find the nearest neighbors. 
+
+        Note: This is a placeholder method to be implemented by subclasses.
+
+        Args:
+            q (numpy.array): The vector to find the nearest neighbors of.
+            n (int): The number of nearest neighbors to return.
+
+        Returns:
+            numpy.array: An array of indices representing the nearest neighbors.
+        """
         return []  # array of candidate indices
 
-    def batch_query(self, X, n):
-        """Provide all queries at once and let algorithm figure out
-        how to handle it. Default implementation uses a ThreadPool
-        to parallelize query processing."""
+    def batch_query(self, X: numpy.array, n: int) -> None:
+        """Performs multiple queries at once and lets the algorithm figure out how to handle it.
+
+        The default implementation uses a ThreadPool to parallelize query processing.
+
+        Args:
+            X (numpy.array): An array of vectors to find the nearest neighbors of.
+            n (int): The number of nearest neighbors to return for each query.
+        Returns: 
+            None: self.get_batch_results() is responsible for retrieving batch result
+        """
         pool = ThreadPool()
         self.res = pool.map(lambda q: self.query(q, n), X)
 
-    def get_batch_results(self):
+    def get_batch_results(self) -> numpy.array:
+        """Retrieves the results of a batch query (from .batch_query()).
+
+        Returns:
+            numpy.array: An array of nearest neighbor results for each query in the batch.
+        """
         return self.res
 
-    def get_additional(self):
+    def get_additional(self) -> Dict[str, Any]:
+        """Returns additional attributes to be stored with the result.
+
+        Returns:
+            dict: A dictionary of additional attributes.
+        """
         return {}
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.name

--- a/ann_benchmarks/algorithms/bruteforce/module.py
+++ b/ann_benchmarks/algorithms/bruteforce/module.py
@@ -1,7 +1,7 @@
 import numpy
 import sklearn.neighbors
 
-from ...distance import metrics as pd
+from ...distance import compute_distance, metrics as pd
 from ..base.module import BaseANN
 
 class BruteForce(BaseANN):
@@ -87,17 +87,17 @@ class BruteForceBLAS(BaseANN):
             # Just compute hamming distance using euclidean distance
             dists = self.lengths - 2 * numpy.dot(self.index, v)
         elif self._metric == "jaccard":
-            dists = [pd[self._metric]["distance"](v, e) for e in self.index]
+            dists = [pd[self._metric].distance(v, e) for e in self.index]
         else:
             # shouldn't get past the constructor!
             assert False, "invalid metric"
         # partition-sort by distance, get `n` closest
         nearest_indices = numpy.argpartition(dists, n)[:n]
-        indices = [idx for idx in nearest_indices if pd[self._metric]["distance_valid"](dists[idx])]
+        indices = [idx for idx in nearest_indices if pd[self._metric].distance_valid(dists[idx])]
 
         def fix(index):
             ep = self.index[index]
             ev = v
-            return (index, pd[self._metric]["distance"](ep, ev))
+            return (index, pd[self._metric].distance(ep, ev))
 
         return map(fix, indices)

--- a/ann_benchmarks/algorithms/qdrant/config.yml
+++ b/ann_benchmarks/algorithms/qdrant/config.yml
@@ -13,7 +13,7 @@ float:
           [ 8, 16, 24, 32, 40, 48, 64, 72 ], #m
           [ 64, 128, 256, 512 ], #ef_construct
         ]
-        query-args: [
+        query_args: [
           [null, 8, 16, 32, 64, 128, 256, 512, 768], #hnsw_ef
           [True, False], # re-score
         ]

--- a/ann_benchmarks/data.py
+++ b/ann_benchmarks/data.py
@@ -1,41 +1,25 @@
-import numpy
+from typing import List, Union, Set, FrozenSet
 
 
-def float_parse_entry(line):
+def float_parse_entry(line: str) -> List[float]:
     return [float(x) for x in line.strip().split()]
 
 
-def float_unparse_entry(entry):
+def float_unparse_entry(entry: List[float]) -> str:
     return " ".join(map(str, entry))
 
 
-def int_parse_entry(line):
+def int_parse_entry(line: str) -> FrozenSet[int]:
     return frozenset([int(x) for x in line.strip().split()])
 
 
-def int_unparse_entry(entry):
+def int_unparse_entry(entry: Union[Set[int], FrozenSet[int]]) -> str:
     return " ".join(map(str, map(int, entry)))
 
 
-def bit_parse_entry(line):
+def bit_parse_entry(line: str) -> List[bool]:
     return [bool(int(x)) for x in list(line.strip().replace(" ", "").replace("\t", ""))]
 
 
-def bit_unparse_entry(entry):
+def bit_unparse_entry(entry: List[bool]) -> str:
     return " ".join(map(lambda el: "1" if el else "0", entry))
-
-
-type_info = {
-    "float": {
-        "type": numpy.float,
-        "parse_entry": float_parse_entry,
-        "unparse_entry": float_unparse_entry,
-        "finish_entries": numpy.vstack,
-    },
-    "bit": {"type": numpy.bool_, "parse_entry": bit_parse_entry, "unparse_entry": bit_unparse_entry},
-    "int": {
-        "type": numpy.object,
-        "parse_entry": int_parse_entry,
-        "unparse_entry": int_unparse_entry,
-    },
-}

--- a/ann_benchmarks/datasets.py
+++ b/ann_benchmarks/datasets.py
@@ -71,8 +71,8 @@ def write_output(train: numpy.ndarray, test: numpy.ndarray, fn: str, distance: s
     brute-force approach.
     
     Args:
-        train (np.ndarray): The training data.
-        test (np.ndarray): The testing data.
+        train (numpy.ndarray): The training data.
+        test (numpy.ndarray): The testing data.
         filename (str): The name of the HDF5 file to which data should be written.
         distance_metric (str): The distance metric to use for computing nearest neighbors.
         point_type (str, optional): The type of the data points. Defaults to "float".
@@ -124,8 +124,8 @@ def write_sparse_output(train: numpy.ndarray, test: numpy.ndarray, fn: str, dist
     brute-force approach.
     
     Args:
-        train (np.ndarray): The sparse training data.
-        test (np.ndarray): The sparse testing data.
+        train (numpy.ndarray): The sparse training data.
+        test (numpy.ndarray): The sparse testing data.
         filename (str): The name of the HDF5 file to which data should be written.
         distance_metric (str): The distance metric to use for computing nearest neighbors.
         dimension (int): The dimensionality of the data.
@@ -143,8 +143,8 @@ def write_sparse_output(train: numpy.ndarray, test: numpy.ndarray, fn: str, dist
         print(f"test size:  {test.shape[0]} * {dimension}")
 
         # Ensure the sets are sorted
-        train = np.array([sorted(t) for t in train])
-        test = np.array([sorted(t) for t in test])
+        train = numpy.array([sorted(t) for t in train])
+        test = numpy.array([sorted(t) for t in test])
 
         # Flatten and write train and test sets
         flat_train = numpy.concatenate(train)
@@ -181,14 +181,14 @@ def train_test_split(X: numpy.ndarray, test_size: int = 10000, dimension: int = 
     Splits the provided dataset into a training set and a testing set.
     
     Args:
-        X (np.ndarray): The dataset to split.
+        X (numpy.ndarray): The dataset to split.
         test_size (int, optional): The number of samples to include in the test set. 
             Defaults to 10000.
         dimension (int, optional): The dimensionality of the data. If not provided, 
             it will be inferred from the second dimension of X. Defaults to None.
 
     Returns:
-        Tuple[np.ndarray, np.ndarray]: A tuple containing the training set and the testing set.
+        Tuple[numpy.ndarray, numpy.ndarray]: A tuple containing the training set and the testing set.
     """
     from sklearn.model_selection import train_test_split as sklearn_train_test_split
 

--- a/ann_benchmarks/datasets.py
+++ b/ann_benchmarks/datasets.py
@@ -63,7 +63,7 @@ def get_dataset(dataset_name: str) -> Tuple[h5py.File, int]:
 
     # here for backward compatibility, to ensure old datasets can still be used with newer versions
     # cast to integer because the json parser (later on) cannot interpret numpy integers
-    dimension = int(hdf5_file.attrs.get("dimension", len(hdf5_file["train"][0])))
+    dimension = int(hdf5_file.attrs["dimension"]) if "dimension" in hdf5_file.attrs else len(hdf5_file["train"][0])
     return hdf5_file, dimension
 
 

--- a/ann_benchmarks/datasets.py
+++ b/ann_benchmarks/datasets.py
@@ -60,7 +60,10 @@ def get_dataset(dataset_name: str) -> Tuple[h5py.File, int]:
             DATASETS[dataset_name](hdf5_filename)
 
     hdf5_file = h5py.File(hdf5_filename, "r")
-    dimension = hdf5_file.attrs.get("dimension", len(hdf5_file["train"][0]))
+
+    # here for backward compatibility, to ensure old datasets can still be used with newer versions
+    # cast to integer because the json parser (later on) cannot interpret numpy integers
+    dimension = int(hdf5_file.attrs.get("dimension", len(hdf5_file["train"][0])))
     return hdf5_file, dimension
 
 

--- a/ann_benchmarks/datasets.py
+++ b/ann_benchmarks/datasets.py
@@ -1,73 +1,115 @@
 import os
 import random
+import tarfile
 from urllib.request import urlopen, urlretrieve
 
 import h5py
 import numpy
+from typing import Any, Callable, Dict, Tuple
+
+def download(source_url: str, destination_path: str) -> None:
+    """
+    Downloads a file from the provided source URL to the specified destination path
+    only if the file doesn't already exist at the destination.
+    
+    Args:
+        source_url (str): The URL of the file to download.
+        destination_path (str): The local path where the file should be saved.
+    """
+    if not os.path.exists(destination_path):
+        print(f"downloading {source_url} -> {destination_path}...")
+        urlretrieve(source_url, destination_path)
 
 
-def download(src, dst):
-    if not os.path.exists(dst):
-        # TODO: should be atomic
-        print("downloading %s -> %s..." % (src, dst))
-        urlretrieve(src, dst)
-
-
-def get_dataset_fn(dataset):
+def get_dataset_fn(dataset_name: str) -> str:
+    """
+    Returns the full file path for a given dataset name in the data directory.
+    
+    Args:
+        dataset_name (str): The name of the dataset.
+    
+    Returns:
+        str: The full file path of the dataset.
+    """
     if not os.path.exists("data"):
         os.mkdir("data")
-    return os.path.join("data", "%s.hdf5" % dataset)
+    return os.path.join("data", f"{dataset_name}.hdf5")
 
 
-def get_dataset(which):
-    hdf5_fn = get_dataset_fn(which)
+def get_dataset(dataset_name: str) -> Tuple[h5py.File, int]:
+    """
+    Fetches a dataset by downloading it from a known URL or creating it locally
+    if it's not already present. The dataset file is then opened for reading, 
+    and the file handle and the dimension of the dataset are returned.
+    
+    Args:
+        dataset_name (str): The name of the dataset.
+    
+    Returns:
+        Tuple[h5py.File, int]: A tuple containing the opened HDF5 file object and
+            the dimension of the dataset.
+    """
+    hdf5_filename = get_dataset_fn(dataset_name)
     try:
-        url = "http://ann-benchmarks.com/%s.hdf5" % which
-        download(url, hdf5_fn)
+        dataset_url = f"http://ann-benchmarks.com/{dataset_name}.hdf5"
+        download(dataset_url, hdf5_filename)
     except:
-        print("Cannot download %s" % url)
-        if which in DATASETS:
+        print(f"Cannot download {dataset_url}")
+        if dataset_name in DATASETS:
             print("Creating dataset locally")
-            DATASETS[which](hdf5_fn)
-    hdf5_f = h5py.File(hdf5_fn, "r")
+            DATASETS[dataset_name](hdf5_filename)
 
-    # here for backward compatibility, to ensure old datasets can still be used with newer versions
-    # cast to integer because the json parser (later on) cannot interpret numpy integers
-    dimension = int(hdf5_f.attrs["dimension"]) if "dimension" in hdf5_f.attrs else len(hdf5_f["train"][0])
-
-    return hdf5_f, dimension
+    hdf5_file = h5py.File(hdf5_filename, "r")
+    dimension = hdf5_file.attrs.get("dimension", len(hdf5_file["train"][0]))
+    return hdf5_file, dimension
 
 
-# Everything below this line is related to creating datasets
-# You probably never need to do this at home,
-# just rely on the prepared datasets at http://ann-benchmarks.com
-
-
-def write_output(train, test, fn, distance, point_type="float", count=100):
+def write_output(train: numpy.ndarray, test: numpy.ndarray, fn: str, distance: str, point_type: str = "float", count: int = 100) -> None:
+    """
+    Writes the provided training and testing data to an HDF5 file. It also computes 
+    and stores the nearest neighbors and their distances for the test set using a 
+    brute-force approach.
+    
+    Args:
+        train (np.ndarray): The training data.
+        test (np.ndarray): The testing data.
+        filename (str): The name of the HDF5 file to which data should be written.
+        distance_metric (str): The distance metric to use for computing nearest neighbors.
+        point_type (str, optional): The type of the data points. Defaults to "float".
+        neighbors_count (int, optional): The number of nearest neighbors to compute for 
+            each point in the test set. Defaults to 100.
+    """
     from ann_benchmarks.algorithms.bruteforce.module import BruteForceBLAS
 
-    f = h5py.File(fn, "w")
-    f.attrs["type"] = "dense"
-    f.attrs["distance"] = distance
-    f.attrs["dimension"] = len(train[0])
-    f.attrs["point_type"] = point_type
-    print("train size: %9d * %4d" % train.shape)
-    print("test size:  %9d * %4d" % test.shape)
-    f.create_dataset("train", (len(train), len(train[0])), dtype=train.dtype)[:] = train
-    f.create_dataset("test", (len(test), len(test[0])), dtype=test.dtype)[:] = test
-    neighbors = f.create_dataset("neighbors", (len(test), count), dtype="i")
-    distances = f.create_dataset("distances", (len(test), count), dtype="f")
-    bf = BruteForceBLAS(distance, precision=train.dtype)
+    with h5py.File(fn, "w") as f:
+        f.attrs["type"] = "dense"
+        f.attrs["distance"] = distance
+        f.attrs["dimension"] = len(train[0])
+        f.attrs["point_type"] = point_type
+        print(f"train size: {train.shape[0]} * {train.shape[1]}")
+        print(f"test size:  {test.shape[0]} * {test.shape[1]}")
+        f.create_dataset("train", data=train)
+        f.create_dataset("test", data=test)
 
-    bf.fit(train)
-    for i, x in enumerate(test):
-        if i % 1000 == 0:
-            print("%d/%d..." % (i, len(test)))
-        res = list(bf.query_with_distances(x, count))
-        res.sort(key=lambda t: t[-1])
-        neighbors[i] = [j for j, _ in res]
-        distances[i] = [d for _, d in res]
-    f.close()
+        # Create datasets for neighbors and distances
+        neighbors_ds = f.create_dataset("neighbors", (len(test), count), dtype=int)
+        distances_ds = f.create_dataset("distances", (len(test), count), dtype=float)
+
+        # Fit the brute-force k-NN model
+        bf = BruteForceBLAS(distance, precision=train.dtype)
+        bf.fit(train)
+
+        for i, x in enumerate(test):
+            if i % 1000 == 0:
+                print(f"{i}/{len(test)}...")
+
+            # Query the model and sort results by distance
+            res = list(bf.query_with_distances(x, count))
+            res.sort(key=lambda t: t[-1])
+
+            # Save neighbors indices and distances
+            neighbors_ds[i] = [idx for idx, _ in res]
+            distances_ds[i] = [dist for _, dist in res]
 
 
 """
@@ -75,54 +117,87 @@ param: train and test are arrays of arrays of indices.
 """
 
 
-def write_sparse_output(train, test, fn, distance, dimension, count=100):
+def write_sparse_output(train: numpy.ndarray, test: numpy.ndarray, fn: str, distance: str, dimension: int, count: int = 100) -> None:
+    """
+    Writes the provided sparse training and testing data to an HDF5 file. It also computes 
+    and stores the nearest neighbors and their distances for the test set using a 
+    brute-force approach.
+    
+    Args:
+        train (np.ndarray): The sparse training data.
+        test (np.ndarray): The sparse testing data.
+        filename (str): The name of the HDF5 file to which data should be written.
+        distance_metric (str): The distance metric to use for computing nearest neighbors.
+        dimension (int): The dimensionality of the data.
+        neighbors_count (int, optional): The number of nearest neighbors to compute for 
+            each point in the test set. Defaults to 100.
+    """
     from ann_benchmarks.algorithms.bruteforce.module import BruteForceBLAS
 
-    f = h5py.File(fn, "w")
-    f.attrs["type"] = "sparse"
-    f.attrs["distance"] = distance
-    f.attrs["dimension"] = dimension
-    f.attrs["point_type"] = "bit"
-    print("train size: %9d * %4d" % (train.shape[0], dimension))
-    print("test size:  %9d * %4d" % (test.shape[0], dimension))
+    with h5py.File(fn, "w") as f:
+        f.attrs["type"] = "sparse"
+        f.attrs["distance"] = distance
+        f.attrs["dimension"] = dimension
+        f.attrs["point_type"] = "bit"
+        print(f"train size: {train.shape[0]} * {dimension}")
+        print(f"test size:  {test.shape[0]} * {dimension}")
 
-    # We ensure the sets are sorted
-    train = numpy.array(list(map(sorted, train)))
-    test = numpy.array(list(map(sorted, test)))
+        # Ensure the sets are sorted
+        train = np.array([sorted(t) for t in train])
+        test = np.array([sorted(t) for t in test])
 
-    flat_train = numpy.hstack(train.flatten())
-    flat_test = numpy.hstack(test.flatten())
+        # Flatten and write train and test sets
+        flat_train = numpy.concatenate(train)
+        flat_test = numpy.concatenate(test)
+        f.create_dataset("train", data=flat_train)
+        f.create_dataset("test", data=flat_test)
 
-    f.create_dataset("train", (len(flat_train),), dtype=flat_train.dtype)[:] = flat_train
-    f.create_dataset("test", (len(flat_test),), dtype=flat_test.dtype)[:] = flat_test
-    neighbors = f.create_dataset("neighbors", (len(test), count), dtype="i")
-    distances = f.create_dataset("distances", (len(test), count), dtype="f")
+        # Create datasets for neighbors and distances
+        neighbors_ds = f.create_dataset("neighbors", (len(test), count), dtype=int)
+        distances_ds = f.create_dataset("distances", (len(test), count), dtype=float)
 
-    f.create_dataset("size_test", (len(test),), dtype="i")[:] = list(map(len, test))
-    f.create_dataset("size_train", (len(train),), dtype="i")[:] = list(map(len, train))
+        # Write sizes of train and test sets
+        f.create_dataset("size_train", data=[len(t) for t in train])
+        f.create_dataset("size_test", data=[len(t) for t in test])
 
-    bf = BruteForceBLAS(distance, precision=train.dtype)
-    bf.fit(train)
-    for i, x in enumerate(test):
-        if i % 1000 == 0:
-            print("%d/%d..." % (i, len(test)))
-        res = list(bf.query_with_distances(x, count))
-        res.sort(key=lambda t: t[-1])
-        neighbors[i] = [j for j, _ in res]
-        distances[i] = [d for _, d in res]
-    f.close()
+        # Fit the brute-force k-NN model
+        bf = BruteForceBLAS(distance, precision=flat_train.dtype)
+        bf.fit(train)
 
+        for i, x in enumerate(test):
+            if i % 1000 == 0:
+                print(f"{i}/{len(test)}...")
+            # Query the model and sort results by distance
+            res = list(bf.query_with_distances(x, count))
+            res.sort(key=lambda t: t[-1])
 
-def train_test_split(X, test_size=10000, dimension=None):
-    import sklearn.model_selection
-
-    if dimension is None:
-        dimension = X.shape[1]
-    print("Splitting %d*%d into train/test" % (X.shape[0], dimension))
-    return sklearn.model_selection.train_test_split(X, test_size=test_size, random_state=1)
+            # Save neighbors indices and distances
+            neighbors_ds[i] = [idx for idx, _ in res]
+            distances_ds[i] = [dist for _, dist in res]
 
 
-def glove(out_fn, d):
+def train_test_split(X: numpy.ndarray, test_size: int = 10000, dimension: int = None) -> Tuple[numpy.ndarray, numpy.ndarray]:
+    """
+    Splits the provided dataset into a training set and a testing set.
+    
+    Args:
+        X (np.ndarray): The dataset to split.
+        test_size (int, optional): The number of samples to include in the test set. 
+            Defaults to 10000.
+        dimension (int, optional): The dimensionality of the data. If not provided, 
+            it will be inferred from the second dimension of X. Defaults to None.
+
+    Returns:
+        Tuple[np.ndarray, np.ndarray]: A tuple containing the training set and the testing set.
+    """
+    from sklearn.model_selection import train_test_split as sklearn_train_test_split
+
+    dimension = dimension if not None else X.shape[1]
+    print(f"Splitting {X.shape[0]}*{dimension} into train/test")
+    return sklearn_train_test_split(X, test_size=test_size, random_state=1)
+
+
+def glove(out_fn: str, d: int) -> None:
     import zipfile
 
     url = "http://nlp.stanford.edu/data/glove.twitter.27B.zip"
@@ -139,7 +214,7 @@ def glove(out_fn, d):
         write_output(numpy.array(X_train), numpy.array(X_test), out_fn, "angular")
 
 
-def _load_texmex_vectors(f, n, k):
+def _load_texmex_vectors(f: Any, n: int, k: int) -> numpy.ndarray:
     import struct
 
     v = numpy.zeros((n, k))
@@ -150,7 +225,7 @@ def _load_texmex_vectors(f, n, k):
     return v
 
 
-def _get_irisa_matrix(t, fn):
+def _get_irisa_matrix(t: tarfile.TarFile, fn: str) -> numpy.ndarray:
     import struct
 
     m = t.getmember(fn)
@@ -161,7 +236,7 @@ def _get_irisa_matrix(t, fn):
     return _load_texmex_vectors(f, n, k)
 
 
-def sift(out_fn):
+def sift(out_fn: str) -> None:
     import tarfile
 
     url = "ftp://ftp.irisa.fr/local/texmex/corpus/sift.tar.gz"
@@ -173,7 +248,7 @@ def sift(out_fn):
         write_output(train, test, out_fn, "euclidean")
 
 
-def gist(out_fn):
+def gist(out_fn: str) -> None:
     import tarfile
 
     url = "ftp://ftp.irisa.fr/local/texmex/corpus/gist.tar.gz"
@@ -185,7 +260,7 @@ def gist(out_fn):
         write_output(train, test, out_fn, "euclidean")
 
 
-def _load_mnist_vectors(fn):
+def _load_mnist_vectors(fn: str) -> numpy.ndarray:
     import gzip
     import struct
 
@@ -215,7 +290,7 @@ def _load_mnist_vectors(fn):
     return numpy.array(vectors)
 
 
-def mnist(out_fn):
+def mnist(out_fn: str) -> None:
     download("http://yann.lecun.com/exdb/mnist/train-images-idx3-ubyte.gz", "mnist-train.gz")  # noqa
     download("http://yann.lecun.com/exdb/mnist/t10k-images-idx3-ubyte.gz", "mnist-test.gz")  # noqa
     train = _load_mnist_vectors("mnist-train.gz")
@@ -223,7 +298,7 @@ def mnist(out_fn):
     write_output(train, test, out_fn, "euclidean")
 
 
-def fashion_mnist(out_fn):
+def fashion_mnist(out_fn: str) -> None:
     download(
         "http://fashion-mnist.s3-website.eu-central-1.amazonaws.com/train-images-idx3-ubyte.gz",  # noqa
         "fashion-mnist-train.gz",
@@ -240,7 +315,7 @@ def fashion_mnist(out_fn):
 # Creates a 'deep image descriptor' dataset using the 'deep10M.fvecs' sample
 # from http://sites.skoltech.ru/compvision/noimi/. The download logic is adapted
 # from the script https://github.com/arbabenko/GNOIMI/blob/master/downloadDeep1B.py.
-def deep_image(out_fn):
+def deep_image(out_fn: str) -> None:
     yadisk_key = "https://yadi.sk/d/11eDCm7Dsn9GA"
     response = urlopen(
         "https://cloud-api.yandex.net/v1/disk/public/resources/download?public_key="
@@ -263,7 +338,7 @@ def deep_image(out_fn):
     write_output(X_train, X_test, out_fn, "angular")
 
 
-def transform_bag_of_words(filename, n_dimensions, out_fn):
+def transform_bag_of_words(filename: str, n_dimensions: int, out_fn: str) -> None:
     import gzip
 
     from scipy.sparse import lil_matrix
@@ -288,7 +363,7 @@ def transform_bag_of_words(filename, n_dimensions, out_fn):
         write_output(numpy.array(X_train), numpy.array(X_test), out_fn, "angular")
 
 
-def nytimes(out_fn, n_dimensions):
+def nytimes(out_fn: str, n_dimensions: int) -> None:
     fn = "nytimes_%s.txt.gz" % n_dimensions
     download(
         "https://archive.ics.uci.edu/ml/machine-learning-databases/bag-of-words/docword.nytimes.txt.gz", fn
@@ -296,7 +371,7 @@ def nytimes(out_fn, n_dimensions):
     transform_bag_of_words(fn, n_dimensions, out_fn)
 
 
-def random_float(out_fn, n_dims, n_samples, centers, distance):
+def random_float(out_fn: str, n_dims: int, n_samples: int, centers: int, distance: str) -> None:
     import sklearn.datasets
 
     X, _ = sklearn.datasets.make_blobs(n_samples=n_samples, n_features=n_dims, centers=centers, random_state=1)
@@ -304,7 +379,7 @@ def random_float(out_fn, n_dims, n_samples, centers, distance):
     write_output(X_train, X_test, out_fn, distance)
 
 
-def random_bitstring(out_fn, n_dims, n_samples, n_queries):
+def random_bitstring(out_fn: str, n_dims: int, n_samples: int, n_queries: int) -> None:
     import sklearn.datasets
 
     Y, _ = sklearn.datasets.make_blobs(n_samples=n_samples, n_features=n_dims, centers=n_queries, random_state=1)
@@ -316,7 +391,7 @@ def random_bitstring(out_fn, n_dims, n_samples, n_queries):
     write_output(X_train, X_test, out_fn, "hamming", "bit")
 
 
-def word2bits(out_fn, path, fn):
+def sift_hamming(out_fn: str, fn: str) -> None:
     import tarfile
 
     local_fn = fn + ".tar.gz"
@@ -334,7 +409,7 @@ def word2bits(out_fn, path, fn):
         write_output(X_train, X_test, out_fn, "hamming", "bit")
 
 
-def sift_hamming(out_fn, fn):
+def sift_hamming(out_fn: str, fn: str) -> None:
     import tarfile
 
     local_fn = fn + ".tar.gz"
@@ -351,7 +426,7 @@ def sift_hamming(out_fn, fn):
         write_output(X_train, X_test, out_fn, "hamming", "bit")
 
 
-def kosarak(out_fn):
+def kosarak(out_fn: str) -> None:
     import gzip
 
     local_fn = "kosarak.dat.gz"
@@ -375,7 +450,7 @@ def kosarak(out_fn):
     write_sparse_output(X_train, X_test, out_fn, "jaccard", dimension)
 
 
-def random_jaccard(out_fn, n=10000, size=50, universe=80):
+def random_jaccard(out_fn: str, n: int = 10000, size: int = 50, universe: int = 80) -> None:
     random.seed(1)
     l = list(range(universe))
     X = []
@@ -386,7 +461,7 @@ def random_jaccard(out_fn, n=10000, size=50, universe=80):
     write_sparse_output(X_train, X_test, out_fn, "jaccard", universe)
 
 
-def lastfm(out_fn, n_dimensions, test_size=50000):
+def lastfm(out_fn: str, n_dimensions: int, test_size: int = 50000) -> None:
     # This tests out ANN methods for retrieval on simple matrix factorization
     # based recommendation algorithms. The idea being that the query/test
     # vectors are user factors and the train set are item factors from
@@ -427,7 +502,7 @@ def lastfm(out_fn, n_dimensions, test_size=50000):
     write_output(item_factors, user_factors, out_fn, "angular")
 
 
-def movielens(fn, ratings_file, out_fn, separator="::", ignore_header=False):
+def movielens(fn: str, ratings_file: str, out_fn: str, separator: str = "::", ignore_header: bool = False) -> None:
     import zipfile
 
     url = "http://files.grouplens.org/datasets/movielens/%s" % fn
@@ -464,19 +539,19 @@ def movielens(fn, ratings_file, out_fn, separator="::", ignore_header=False):
         write_sparse_output(X_train, X_test, out_fn, "jaccard", dimension)
 
 
-def movielens1m(out_fn):
+def movielens1m(out_fn: str) -> None:
     movielens("ml-1m.zip", "ml-1m/ratings.dat", out_fn)
 
 
-def movielens10m(out_fn):
+def movielens10m(out_fn: str) -> None:
     movielens("ml-10m.zip", "ml-10M100K/ratings.dat", out_fn)
 
 
-def movielens20m(out_fn):
+def movielens20m(out_fn: str) -> None:
     movielens("ml-20m.zip", "ml-20m/ratings.csv", out_fn, ",", True)
 
 
-DATASETS = {
+DATASETS: Dict[str, Callable[[str], None]] = {
     "deep-image-96-angular": deep_image,
     "fashion-mnist-784-euclidean": fashion_mnist,
     "gist-960-euclidean": gist,

--- a/ann_benchmarks/definitions.py
+++ b/ann_benchmarks/definitions.py
@@ -1,37 +1,66 @@
 import collections
+from dataclasses import dataclass
 import importlib
 import os
 import glob
 from enum import Enum
 from itertools import product
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
+from ann_benchmarks.algorithms.base.module import BaseANN
 
 import yaml
 
-Definition = collections.namedtuple(
-    "Definition", ["algorithm", "constructor", "module", "docker_tag", "arguments", "query_argument_groups", "disabled"]
-)
+@dataclass
+class Definition:
+    algorithm: str
+    constructor: str
+    module: str
+    docker_tag: str
+    arguments: List[Any]
+    query_argument_groups: List[List[Any]]
+    disabled: bool
 
-
-def instantiate_algorithm(definition: Definition):
-    """Creates a `BaseANN` object for a specific algorithm definition.
-     
-    The constructor for the algorithm definition is, generally, located at ann_benchmarks/algorithms/*/module.py.
+def instantiate_algorithm(definition: Definition) -> BaseANN:
     """
-    print("Trying to instantiate %s.%s(%s)" % (definition.module, definition.constructor, definition.arguments))
+    Create a `BaseANN` from a definition.
+     
+    Args:
+        definition (Definition): An object containing information about the algorithm.
+
+    Returns:
+        BaseANN: Instantiated algorithm
+
+    Note:
+        The constructors for the algorithm definition are generally located at 
+        ann_benchmarks/algorithms/*/module.py.
+    """
+    print(f"Trying to instantiate {definition.module}.{definition.constructor}({definition.arguments})")
     module = importlib.import_module(f"{definition.module}.module")
     constructor = getattr(module, definition.constructor)
     return constructor(*definition.arguments)
 
 
 class InstantiationStatus(Enum):
+    """Possible status of instantiating an algorithm from a python module import."""
     AVAILABLE = 0
     NO_CONSTRUCTOR = 1
     NO_MODULE = 2
 
 
-def algorithm_status(definition):
+def algorithm_status(definition: Definition) -> InstantiationStatus:
+    """
+    Determine the instantiation status of the algorithm based on its python module and constructor.
+
+    Attempts to find the Python class constructor based on the definition's module path and 
+    constructor name.
+
+    Args:
+        definition (Definition): The algorithm definition containing module and constructor.
+
+    Returns:
+        InstantiationStatus: The status of the algorithm instantiation.
+    """
     try:
         module = importlib.import_module(definition.module)
         if hasattr(module, definition.constructor):
@@ -42,7 +71,20 @@ def algorithm_status(definition):
         return InstantiationStatus.NO_MODULE
 
 
-def _generate_combinations(args):
+def _generate_combinations(args: Union[List[Any], Dict[Any, Any]]) -> List[Union[List[Any], Dict[Any, Any]]]:
+    """
+    Generate combinations of elements from args, either the list or combinations of key-value pairs in a dict.
+
+    Args:
+        args (Union[List[Any], Dict[Any, Any]]): Input list or dict to generate combinations from.
+
+    Returns:
+        List[Union[List[Any], Dict[Any, Any]]]: List of combinations generated from input.
+
+    Raises:
+        TypeError: If input is neither a list nor a dict.
+    """
+
     if isinstance(args, list):
         args = [el if isinstance(el, list) else [el] for el in args]
         return [list(x) for x in product(*args)]
@@ -55,12 +97,24 @@ def _generate_combinations(args):
                 flat.append([(k, v)])
         return [dict(x) for x in product(*flat)]
     else:
-        raise TypeError("No args handling exists for %s" % type(args).__name__)
+        raise TypeError(f"No args handling exists for {type(args).__name__}")
 
 
-def _substitute_variables(arg, vs):
+def _substitute_variables(arg: Any, vs: Dict[str, Any]) -> Any:
+    """
+    Substitutes any string variables present in the argument structure with provided values.
+    
+    Support for nested substitution in the case `arg` is a List or Dict.
+
+    Args:
+        arg (Any): The argument structure, can be of type dict, list, or str.
+        variable_substitutions (Dict[str, Any]): A mapping variable names to their values.
+
+    Returns:
+        Any: The argument structure with variables substituted by their corresponding values.
+    """
     if isinstance(arg, dict):
-        return dict([(k, _substitute_variables(v, vs)) for k, v in arg.items()])
+        return {k: _substitute_variables(v, vs) for k, v in arg.items()}
     elif isinstance(arg, list):
         return [_substitute_variables(a, vs) for a in arg]
     elif isinstance(arg, str) and arg in vs:
@@ -68,13 +122,13 @@ def _substitute_variables(arg, vs):
     else:
         return arg
 
+
 def get_config_files(base_dir: str = "ann_benchmarks/algorithms") -> List[str]:
     """Get config files for all algorithms."""
     config_files = glob.glob(os.path.join(base_dir, "*", "config.yml"))
     return list(
         set(config_files) - {f"{base_dir}/base/config.yml"}
     )
-
 
 def load_configs(point_type: str, base_dir: str = "ann_benchmarks/algorithms") -> Dict[str, Any]:
     """Load algorithm configurations for a given point_type."""
@@ -91,7 +145,7 @@ def load_configs(point_type: str, base_dir: str = "ann_benchmarks/algorithms") -
                 print(f"Error loading YAML from {config_file}: {e}")
     return configs
 
-def _get_definitions(base_dir: str = "ann_benchmarks/algorithms"):
+def _get_definitions(base_dir: str = "ann_benchmarks/algorithms") -> Dict[str, Dict[str, Any]]:
     """Load algorithm configurations for a given point_type."""
     config_files = get_config_files(base_dir=base_dir)
     configs = {}
@@ -152,81 +206,141 @@ def _get_algorithm_definitions(point_type: str, distance_metric: str) -> Dict[st
     return definitions
 
 def list_algorithms(base_dir: str = "ann_benchmarks/algorithms") -> None:
-    """Output a list of all algorithms, with their supported point types and metrics."""
+    """
+    Output (to stdout), a list of all algorithms, with their supported point types and metrics.
+    
+    Args:
+        base_dir (str, optional): The base directory where the algorithms are stored. 
+                                  Defaults to "ann_benchmarks/algorithms".
+    """
     definitions = _get_definitions(base_dir)
 
     print("The following algorithms are supported...", definitions)
     for algorithm in definitions:
         print('\t... for the algorithm "%s"...' % algorithm)
+
         for point_type in definitions[algorithm]:
             print('\t\t... and the point type "%s", metrics: ' % point_type)
+
             for metric in definitions[algorithm][point_type]:
                 print("\t\t\t%s" % metric)
 
-def create_definitions_from_algorithm(name: str, algo: Dict[str, Any], dimension, point_type="float", distance_metric="euclidean", count=10) -> List[Definition]:
+
+def generate_arg_combinations(run_group: Dict[str, Any], arg_type: str) -> List:
+    """Generate combinations of arguments from a run group for a specific argument type.
+    
+    Args:
+        run_group (Dict[str, Any]): The run group containing argument definitions.
+        arg_type (str): The type of argument group to generate combinations for.
+
+    Returns:
+        List: A list of combinations of arguments.
+    """
+    if arg_type not in run_group:
+        return []
+    
+    groups = [
+        _generate_combinations(arg_group) if isinstance(arg_group, dict) else arg_group
+        for arg_group in run_group[arg_type]
+    ]
+    return _generate_combinations(groups)
+
+
+def prepare_args(run_group: Dict[str, Any]) -> List:
+    """For an Algorithm's run group, prepare arguments. 
+    
+    An `arg_groups` is preferenced over an `args` key.
+    
+    Args:
+        run_group (Dict[str, Any]): The run group containing argument definitions.
+
+    Returns:
+        List: A list of prepared arguments.
+
+    Raises:
+        ValueError: If the structure of the run group is not recognized.
+    """
+    if "args" in run_group or "arg_groups" in run_group:
+        return generate_arg_combinations(run_group, "arg_groups" if "arg_groups" in run_group else "args")
+    else:
+        raise ValueError(f"Unknown run_group structure: {run_group}")
+
+
+def prepare_query_args(run_group: Dict[str, Any]) -> List:
+    """For an algorithm's run group, prepare query args/ query arg groups.
+    
+    Args:
+        run_group (Dict[str, Any]): The run group containing argument definitions.
+
+    Returns:
+        List: A list of prepared query arguments.
+    """
+    if "query_args" in run_group or "query_arg_groups" in run_group:
+        return generate_arg_combinations(run_group, "query_arg_groups" if "query_arg_groups" in run_group else "query_args")
+    else:
+        return []
+
+
+def create_definitions_from_algorithm(name: str, algo: Dict[str, Any], dimension: int, distance_metric: str = "euclidean", count: int = 10) -> List[Definition]:
+    """
+    Create definitions from an indvidual algorithm. An algorithm (e.g. annoy) can have multiple
+     definitions based on various run groups (see config.ymls for clear examples). 
+    
+    Args:
+        name (str): Name of the algorithm.
+        algo (Dict[str, Any]): Dictionary with algorithm parameters.
+        dimension (int): Dimension of the algorithm.
+        distance_metric (str, optional): Distance metric used by the algorithm. Defaults to "euclidean".
+        count (int, optional): Count of the definitions to be created. Defaults to 10.
+    
+    Raises:
+        Exception: If the algorithm does not define "docker_tag", "module" or "constructor" properties.
+    
+    Returns:
+        List[Definition]: A list of definitions created from the algorithm.
+    """
+    required_properties = ["docker_tag", "module", "constructor"]
+    missing_properties = [prop for prop in required_properties if prop not in algo]
+    if missing_properties:
+        raise ValueError(f"Algorithm {name} is missing the following properties: {', '.join(missing_properties)}")
+    
+    base_args = algo.get("base_args", [])
+    
     definitions = []
-    for k in ["docker_tag", "module", "constructor"]:
-            if k not in algo:
-                raise Exception('algorithm %s does not define a "%s" property' % (name, k))
-
-    base_args = []
-    if "base_args" in algo:
-        base_args = algo["base_args"]
-
     for run_group in algo["run_groups"].values():
-        if "arg_groups" in run_group:
-            groups = []
-            for arg_group in run_group["arg_groups"]:
-                if isinstance(arg_group, dict):
-                    # Dictionaries need to be expanded into lists in order
-                    # for the subsequent call to _generate_combinations to
-                    # do the right thing
-                    groups.append(_generate_combinations(arg_group))
-                else:
-                    groups.append(arg_group)
-            args = _generate_combinations(groups)
-        elif "args" in run_group:
-            args = _generate_combinations(run_group["args"])
-        else:
-            assert False, "? what? %s" % run_group
+        args = prepare_args(run_group)
+        query_args = prepare_query_args(run_group)
 
-        if "query_arg_groups" in run_group:
-            groups = []
-            for arg_group in run_group["query_arg_groups"]:
-                if isinstance(arg_group, dict):
-                    groups.append(_generate_combinations(arg_group))
-                elif len(arg_group) > 0:
-                    groups.append(arg_group)
-            query_args = _generate_combinations(groups)
-        elif "query_args" in run_group:
-            query_args = _generate_combinations(run_group["query_args"])
-        else:
-            query_args = []
-        
         for arg_group in args:
-            aargs = []
-            aargs.extend(base_args)
+            current_args = []
+            current_args.extend(base_args)
             if isinstance(arg_group, list):
-                aargs.extend(arg_group)
+                current_args.extend(arg_group)
             else:
-                aargs.append(arg_group)
+                current_args.append(arg_group)
 
             vs = {"@count": count, "@metric": distance_metric, "@dimension": dimension}
-            aargs = [_substitute_variables(arg, vs) for arg in aargs]
+            current_args = [_substitute_variables(arg, vs) for arg in current_args]
+            
             definitions.append(
                 Definition(
                     algorithm=name,
                     docker_tag=algo["docker_tag"],
                     module=algo["module"],
                     constructor=algo["constructor"],
-                    arguments=aargs,
+                    arguments=current_args,
                     query_argument_groups=query_args,
                     disabled=algo.get("disabled", False),
                 )
             )
     return definitions
 
-def get_definitions(definition_file, dimension, point_type="float", distance_metric="euclidean", count=10) -> List[Definition]:
+def get_definitions(
+    dimension: int, 
+    point_type: str = "float", 
+    distance_metric: str = "euclidean", 
+    count: int = 10
+) -> List[Definition]:
     algorithm_definitions = _get_algorithm_definitions(point_type=point_type,  distance_metric=distance_metric)
 
     definitions: List[Definition] = []
@@ -234,7 +348,7 @@ def get_definitions(definition_file, dimension, point_type="float", distance_met
     # Map this for each config.yml
     for (name, algo) in algorithm_definitions.items():
         definitions.extend(
-            create_definitions_from_algorithm(name, algo, dimension, point_type, distance_metric, count)
+            create_definitions_from_algorithm(name, algo, dimension, distance_metric, count)
         )
         
 

--- a/ann_benchmarks/definitions.py
+++ b/ann_benchmarks/definitions.py
@@ -236,14 +236,21 @@ def generate_arg_combinations(run_group: Dict[str, Any], arg_type: str) -> List:
     Returns:
         List: A list of combinations of arguments.
     """
-    if arg_type not in run_group:
+    if arg_type in ["arg_groups", "query_arg_groups"]:
+        groups = []
+        for arg_group in run_group[arg_type]:
+            if isinstance(arg_group, dict):
+                # Dictionaries need to be expanded into lists in order
+                # for the subsequent call to _generate_combinations to
+                # do the right thing
+                groups.append(_generate_combinations(arg_group))
+            else:
+                groups.append(arg_group)
+        return _generate_combinations(groups)
+    elif arg_type in ["args", "query_args"]:
+        return _generate_combinations(run_group[arg_type])
+    else:
         return []
-    
-    groups = [
-        _generate_combinations(arg_group) if isinstance(arg_group, dict) else arg_group
-        for arg_group in run_group[arg_type]
-    ]
-    return _generate_combinations(groups)
 
 
 def prepare_args(run_group: Dict[str, Any]) -> List:

--- a/ann_benchmarks/distance.py
+++ b/ann_benchmarks/distance.py
@@ -1,10 +1,13 @@
+from typing import Callable, List, NamedTuple, Tuple, Union
+
+import h5py
 import numpy as np
 
 # Need own implementation of jaccard because scipy's
 # implementation is different
 
 
-def jaccard(a, b):
+def jaccard(a: List[int], b: List[int]) -> float:
     if len(a) == 0 or len(b) == 0:
         return 0
     intersect = len(set(a) & set(b))
@@ -18,44 +21,105 @@ def norm(a):
 def euclidean(a, b):
     return norm(a - b)
 
+class Metric(NamedTuple):
+    distance: Callable[[np.ndarray, np.ndarray], float]
+    distance_valid: Callable[[float], bool]
 
 metrics = {
-    "hamming": {
-        "distance": lambda a, b: np.sum(a.astype(np.bool_) ^ b.astype(np.bool_)),
-        "distance_valid": lambda a: True,
-    },
-    # return 1 - jaccard similarity, because smaller distances are better.
-    "jaccard": {
-        "distance": lambda a, b: 1 - jaccard(a, b),
-        "distance_valid": lambda a: a < 1 - 1e-5,
-    },
-    "euclidean": {
-        "distance": lambda a, b: euclidean(a, b),
-        "distance_valid": lambda a: True,
-    },
-    "angular": {
-        "distance": lambda a, b: 1 - np.dot(a, b) / (norm(a) * norm(b)),
-        "distance_valid": lambda a: True,
-    },
+    "hamming": Metric(
+        distance=lambda a, b: np.sum(a.astype(np.bool_) ^ b.astype(np.bool_)),
+        distance_valid=lambda a: True
+    ),
+    "jaccard": Metric(
+        distance=lambda a, b: 1 - jaccard(a, b),
+        distance_valid=lambda a: a < 1 - 1e-5
+    ),
+    "euclidean": Metric(
+        distance=lambda a, b: euclidean(a, b),
+        distance_valid=lambda a: True
+    ),
+    "angular": Metric(
+        distance=lambda a, b: 1 - np.dot(a, b) / (norm(a) * norm(b)),
+        distance_valid=lambda a: True
+    ),
 }
 
+def compute_distance(metric: str, a: np.ndarray, b: np.ndarray) -> float:
+    """
+    Compute the distance between two points according to a specified metric.
 
-def sparse_to_lists(data, lengths):
-    X = []
-    index = 0
-    for l in lengths:
-        X.append(data[index : index + l])
-        index += l
+    Args:
+        metric (str): The name of the metric to use. Must be a key in the 'metrics' dictionary.
+        a (np.ndarray): The first point.
+        b (np.ndarray): The second point.
 
-    return X
+    Returns:
+        float: The computed distance.
+
+    Raises:
+        KeyError: If the specified metric is not found in the 'metrics' dictionary.
+    """
+    if metric not in metrics:
+        raise KeyError(f"Unknown metric '{metric}'. Known metrics are {list(metrics.keys())}")
+
+    return metrics[metric].distance(a, b)
 
 
-def dataset_transform(dataset):
+def is_distance_valid(metric: str, distance: float) -> bool:
+    """
+    Check if a computed distance is valid according to a specified metric.
+
+    Args:
+        metric (str): The name of the metric to use. Must be a key in the 'metrics' dictionary.
+        distance (float): The computed distance to check.
+
+    Returns:
+        bool: True if the distance is valid, False otherwise.
+
+    Raises:
+        KeyError: If the specified metric is not found in the 'metrics' dictionary.
+    """
+    if metric not in metrics:
+        raise KeyError(f"Unknown metric '{metric}'. Known metrics are {list(metrics.keys())}")
+
+    return metrics[metric].distance_valid(distance)
+
+
+def convert_sparse_to_list(data: np.ndarray, lengths: List[int]) -> List[np.ndarray]:
+    """
+    Converts sparse data into a list of arrays, where each array represents a separate data sample.
+
+    Args:
+        data (np.ndarray): The input sparse data represented as a numpy array.
+        lengths (List[int]): List of lengths for each data sample in the sparse data.
+
+    Returns:
+        List[np.ndarray]: A list of arrays where each array is a data sample.
+    """
+    return [
+        data[i - l : i] for i, l in zip(np.cumsum(lengths), lengths)
+    ]
+
+
+def dataset_transform(dataset: h5py.Dataset) -> Tuple[Union[np.ndarray, List[np.ndarray]], Union[np.ndarray, List[np.ndarray]]]:
+    """
+    Transforms the dataset from the HDF5 format to conventional numpy format.
+
+    If the dataset is dense, it's returned as a numpy array.
+    If it's sparse, it's transformed into a list of numpy arrays, each representing a data sample.
+
+    Args:
+        dataset (h5py.Dataset): The input dataset in HDF5 format.
+
+    Returns:
+        Tuple[Union[np.ndarray, List[np.ndarray]], Union[np.ndarray, List[np.ndarray]]]: Tuple of training and testing data in conventional format.
+    """
     if dataset.attrs.get("type", "dense") != "sparse":
         return np.array(dataset["train"]), np.array(dataset["test"])
 
     # we store the dataset as a list of integers, accompanied by a list of lengths in hdf5
     # so we transform it back to the format expected by the algorithms here (array of array of ints)
-    return sparse_to_lists(dataset["train"], dataset["size_train"]), sparse_to_lists(
-        dataset["test"], dataset["size_test"]
+    return (
+        convert_sparse_to_list(dataset["train"], dataset["size_train"]),
+        convert_sparse_to_list(dataset["test"], dataset["size_test"])
     )

--- a/ann_benchmarks/main.py
+++ b/ann_benchmarks/main.py
@@ -1,4 +1,6 @@
 import argparse
+from dataclasses import replace
+import h5py
 import logging
 import logging.config
 import multiprocessing.pool
@@ -6,30 +8,62 @@ import os
 import random
 import shutil
 import sys
+from typing import List
 
 import docker
 import psutil
 
-from .definitions import (InstantiationStatus, algorithm_status,
+from .definitions import (Definition, InstantiationStatus, algorithm_status,
                                      get_definitions, list_algorithms)
 from .constants import INDEX_DIR
 from .datasets import DATASETS, get_dataset
-from .results import get_result_filename
+from .results import build_result_filepath
 from .runner import run, run_docker
 
 
-def positive_int(s):
-    i = None
+logging.config.fileConfig("logging.conf")
+logger = logging.getLogger("annb")
+
+
+def positive_int(input_str: str) -> int:
+    """
+    Validates if the input string can be converted to a positive integer.
+
+    Args:
+        input_str (str): The input string to validate and convert to a positive integer.
+
+    Returns:
+        int: The validated positive integer.
+
+    Raises:
+        argparse.ArgumentTypeError: If the input string cannot be converted to a positive integer.
+    """
     try:
-        i = int(s)
+        i = int(input_str)
+        if i < 1:
+            raise ValueError
     except ValueError:
-        pass
-    if not i or i < 1:
-        raise argparse.ArgumentTypeError("%r is not a positive integer" % s)
+        raise argparse.ArgumentTypeError(f"{input_str} is not a positive integer")
+
     return i
 
 
-def run_worker(cpu, args, queue):
+def run_worker(cpu: int, args: argparse.Namespace, queue: multiprocessing.Queue[Definition]) -> None:
+    """
+    Executes the algorithm based on the provided parameters.
+
+    The algorithm is either executed directly or through a Docker container based on the `args.local`
+     argument. The function runs until the queue is emptied. When running in a docker container, it 
+    executes the algorithm in a Docker container.
+
+    Args:
+        cpu (int): The CPU number to be used in the execution.
+        args (argparse.Namespace): User provided arguments for running workers. 
+        queue (multiprocessing.Queue): The multiprocessing queue that contains the algorithm definitions.
+
+    Returns:
+        None
+    """
     while not queue.empty():
         definition = queue.get()
         if args.local:
@@ -37,14 +71,12 @@ def run_worker(cpu, args, queue):
         else:
             memory_margin = 500e6  # reserve some extra memory for misc stuff
             mem_limit = int((psutil.virtual_memory().available - memory_margin) / args.parallelism)
-            cpu_limit = str(cpu)
-            if args.batch:
-                cpu_limit = "0-%d" % (multiprocessing.cpu_count() - 1)
-
+            cpu_limit = str(cpu) if not args.batch else f"0-3" # {multiprocessing.cpu_count() - 1}"
+            
             run_docker(definition, args.dataset, args.count, args.runs, args.timeout, args.batch, cpu_limit, mem_limit)
 
 
-def main():
+def parse_arguments() -> argparse.Namespace:
     parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument(
         "--dataset",
@@ -95,123 +127,219 @@ def main():
     args = parser.parse_args()
     if args.timeout == -1:
         args.timeout = None
+    return args
+
+
+def filter_already_run_definitions(
+    definitions: List[Definition], 
+    dataset: h5py.File, 
+    count: int, 
+    batch: bool, 
+    force: bool
+) -> List[Definition]:
+    """Filters out the algorithm definitions based on whether they have already been run or not.
+
+    This function checks if there are existing results for each definition by constructing the 
+    result filename from the algorithm definition and the provided arguments. If there are no 
+    existing results or if the parameter `force=True`, the definition is kept. Otherwise, it is
+    discarded.
+
+    Args:
+        definitions (List[Definition]): A list of algorithm definitions to be filtered.
+        dataset (str): The name of the dataset to load training points from.
+        force (bool): If set, re-run algorithms even if their results already exist.
+
+        count (int): The number of near neighbours to search for (only used in file naming convention).
+        batch (bool): If set, algorithms get all queries at once (only used in file naming convention).
+
+    Returns:
+        List[Definition]: A list of algorithm definitions that either have not been run or are 
+                          forced to be re-run.
+    """
+    filtered_definitions = []
+
+    for definition in definitions:
+        not_yet_run = [
+            query_args 
+            for query_args in (definition.query_argument_groups or [[]])
+            if force or not os.path.exists(build_result_filepath(dataset.name, count, definition, query_args, batch))
+        ]
+
+        if not_yet_run:
+            definition = replace(definition, query_argument_groups=not_yet_run) if definition.query_argument_groups else definition
+            filtered_definitions.append(definition)
+            
+    return filtered_definitions
+
+
+def filter_by_available_docker_images(definitions: List[Definition]) -> List[Definition]:
+    """
+    Filters out the algorithm definitions that do not have an associated, available Docker images.
+
+    This function uses the Docker API to list all Docker images available in the system. It 
+    then checks the Docker tags associated with each algorithm definition against the list 
+    of available Docker images, filtering out those that are unavailable. 
+
+    Args:
+        definitions (List[Definition]): A list of algorithm definitions to be filtered.
+
+    Returns:
+        List[Definition]: A list of algorithm definitions that are associated with available Docker images.
+    """
+    docker_client = docker.from_env()
+    docker_tags = {tag.split(":")[0] for image in docker_client.images.list() for tag in image.tags}
+
+    missing_docker_images = set(d.docker_tag for d in definitions).difference(docker_tags)
+    if missing_docker_images:
+        logger.info(f"not all docker images available, only: {docker_tags}")
+        logger.info(f"missing docker images: {missing_docker_images}")
+        definitions = [d for d in definitions if d.docker_tag in docker_tags]
+    
+    return definitions
+
+
+def check_module_import_and_constructor(df: Definition) -> bool:
+    """
+    Verifies if the algorithm module can be imported and its constructor exists.
+
+    This function checks if the module specified in the definition can be imported. 
+    Additionally, it verifies if the constructor for the algorithm exists within the 
+    imported module.
+
+    Args:
+        df (Definition): A definition object containing the module and constructor 
+        for the algorithm.
+
+    Returns:
+        bool: True if the module can be imported and the constructor exists, False 
+        otherwise.
+    """
+    status = algorithm_status(df)
+    if status == InstantiationStatus.NO_CONSTRUCTOR:
+        raise Exception(
+            f"{df.module}.{df.constructor}({df.arguments}): error: the module '{df.module}' does not expose the named constructor"
+        )
+    if status == InstantiationStatus.NO_MODULE:
+        logging.warning(
+            f"{df.module}.{df.constructor}({df.arguments}): the module '{df.module}' could not be loaded; skipping"
+        )
+        return False
+    
+    return True
+
+def create_workers_and_execute(definitions: List[Definition], args: argparse.Namespace):
+    """
+    Manages the creation, execution, and termination of worker processes based on provided arguments.
+
+    Args:
+        definitions (List[Definition]): List of algorithm definitions to be processed.
+        args (argparse.Namespace): User provided arguments for running workers. 
+
+    Raises:
+        Exception: If the level of parallelism exceeds the available CPU count or if batch mode is on with more than 
+                   one worker.
+    """
+    cpu_count = multiprocessing.cpu_count()
+    if args.parallelism > cpu_count - 1:
+        raise Exception(f"Parallelism larger than {cpu_count - 1}! (CPU count minus one)")
+
+    if args.batch and args.parallelism > 1:
+        raise Exception(
+            f"Batch mode uses all available CPU resources, --parallelism should be set to 1. (Was: {args.parallelism})"
+        )
+
+    task_queue = multiprocessing.Queue()
+    for definition in definitions:
+        task_queue.put(definition)
+
+    try:
+        workers = [multiprocessing.Process(target=run_worker, args=(i + 1, args, task_queue)) for i in range(args.parallelism)]
+        [worker.start() for worker in workers]
+        [worker.join() for worker in workers]
+    finally:
+        logger.info("Terminating %d workers" % len(workers))
+        [worker.terminate() for worker in workers]
+
+
+def filter_disabled_algorithms(definitions: List[Definition]) -> List[Definition]:
+    """
+    Excludes disabled algorithms from the given list of definitions.
+
+    This function filters out the algorithm definitions that are marked as disabled in their `config.yml`.
+
+    Args:
+        definitions (List[Definition]): A list of algorithm definitions.
+
+    Returns:
+        List[Definition]: A list of algorithm definitions excluding any that are disabled.
+    """
+    disabled_algorithms = [d for d in definitions if d.disabled]
+    if disabled_algorithms:
+        logger.info(f"Not running disabled algorithms {disabled_algorithms}")
+
+    return [d for d in definitions if not d.disabled]
+
+
+def limit_algorithms(definitions: List[Definition], limit: int) -> List[Definition]:
+    """
+    Limits the number of algorithm definitions based on the given limit.
+
+    If the limit is negative, all definitions are returned. For valid 
+    sampling, `definitions` should be shuffled before `limit_algorithms`.
+
+    Args:
+        definitions (List[Definition]): A list of algorithm definitions.
+        limit (int): The maximum number of definitions to return.
+
+    Returns:
+        List[Definition]: A trimmed list of algorithm definitions.
+    """
+    return definitions if limit < 0 else definitions[:limit]
+
+
+def main():
+    args = parse_arguments()
 
     if args.list_algorithms:
         list_algorithms(args.definitions)
         sys.exit(0)
 
-    logging.config.fileConfig("logging.conf")
-    logger = logging.getLogger("annb")
-
-    # Nmslib specific code
-    # Remove old indices stored on disk
     if os.path.exists(INDEX_DIR):
         shutil.rmtree(INDEX_DIR)
 
     dataset, dimension = get_dataset(args.dataset)
-    point_type = dataset.attrs.get("point_type", "float")
-    distance = dataset.attrs["distance"]
-    definitions = get_definitions(args.definitions, dimension, point_type, distance, args.count)
-
-    # Filter out, from the loaded definitions, all those query argument groups
-    # that correspond to experiments that have already been run. (This might
-    # mean removing a definition altogether, so we can't just use a list
-    # comprehension.)
-    filtered_definitions = []
-    for definition in definitions:
-        query_argument_groups = definition.query_argument_groups
-        if not query_argument_groups:
-            query_argument_groups = [[]]
-        not_yet_run = []
-        for query_arguments in query_argument_groups:
-            fn = get_result_filename(args.dataset, args.count, definition, query_arguments, args.batch)
-            if args.force or not os.path.exists(fn):
-                not_yet_run.append(query_arguments)
-        if not_yet_run:
-            if definition.query_argument_groups:
-                definition = definition._replace(query_argument_groups=not_yet_run)
-            filtered_definitions.append(definition)
-    definitions = filtered_definitions
-
+    definitions: List[Definition] = get_definitions(
+        dimension=dimension,
+        point_type=dataset.attrs.get("point_type", "float"),
+        distance_metric=dataset.attrs["distance"],
+        count=args.count
+    )
     random.shuffle(definitions)
+
+    definitions = filter_already_run_definitions(definitions, 
+        dataset=dataset, 
+        count=args.count, 
+        batch=args.batch, 
+        force=args.force,
+    )
 
     if args.algorithm:
         logger.info(f"running only {args.algorithm}")
         definitions = [d for d in definitions if d.algorithm == args.algorithm]
 
     if not args.local:
-        # See which Docker images we have available
-        docker_client = docker.from_env()
-        docker_tags = set()
-        for image in docker_client.images.list():
-            for tag in image.tags:
-                tag = tag.split(":")[0]
-                docker_tags.add(tag)
-
-        if args.docker_tag:
-            logger.info(f"running only {args.docker_tag}")
-            definitions = [d for d in definitions if d.docker_tag == args.docker_tag]
-
-        if set(d.docker_tag for d in definitions).difference(docker_tags):
-            logger.info(f"not all docker images available, only: {set(docker_tags)}")
-            logger.info(
-                f"missing docker images: " f"{str(set(d.docker_tag for d in definitions).difference(docker_tags))}"
-            )
-            definitions = [d for d in definitions if d.docker_tag in docker_tags]
+        definitions = filter_by_available_docker_images(definitions)
     else:
+        definitions = list(filter(
+            check_module_import_and_constructor, definitions
+        ))
 
-        def _test(df):
-            status = algorithm_status(df)
-            # If the module was loaded but doesn't actually have a constructor
-            # of the right name, then the definition is broken
-            if status == InstantiationStatus.NO_CONSTRUCTOR:
-                raise Exception(
-                    "%s.%s(%s): error: the module '%s' does not"
-                    " expose the named constructor" % (df.module, df.constructor, df.arguments, df.module)
-                )
-
-            if status == InstantiationStatus.NO_MODULE:
-                # If the module couldn't be loaded (presumably because
-                # of a missing dependency), print a warning and remove
-                # this definition from the list of things to be run
-                logging.warning(
-                    "%s.%s(%s): the module '%s' could not be "
-                    "loaded; skipping" % (df.module, df.constructor, df.arguments, df.module)
-                )
-                return False
-            else:
-                return True
-
-        definitions = [d for d in definitions if _test(d)]
-
-    if not args.run_disabled:
-        if len([d for d in definitions if d.disabled]):
-            logger.info(f"Not running disabled algorithms {[d for d in definitions if d.disabled]}")
-        definitions = [d for d in definitions if not d.disabled]
-
-    if args.max_n_algorithms >= 0:
-        definitions = definitions[: args.max_n_algorithms]
+    definitions = filter_disabled_algorithms(definitions) if not args.run_disabled else definitions
+    definitions = limit_algorithms(definitions, args.max_n_algorithms)
 
     if len(definitions) == 0:
         raise Exception("Nothing to run")
     else:
         logger.info(f"Order: {definitions}")
 
-    if args.parallelism > multiprocessing.cpu_count() - 1:
-        raise Exception("Parallelism larger than %d! (CPU count minus one)" % (multiprocessing.cpu_count() - 1))
-
-    # Multiprocessing magic to farm this out to all CPUs
-    queue = multiprocessing.Queue()
-    for definition in definitions:
-        queue.put(definition)
-    if args.batch and args.parallelism > 1:
-        raise Exception(
-            f"Batch mode uses all available CPU resources, --parallelism should be set to 1. (Was: {args.parallelism})"
-        )
-    try:
-        workers = [multiprocessing.Process(target=run_worker, args=(i + 1, args, queue)) for i in range(args.parallelism)]
-        [worker.start() for worker in workers]
-        [worker.join() for worker in workers]
-    finally:
-        logger.info("Terminating %d workers" % len(workers))
-        [worker.terminate() for worker in workers]
+    create_workers_and_execute(definitions, args)

--- a/ann_benchmarks/main.py
+++ b/ann_benchmarks/main.py
@@ -48,7 +48,7 @@ def positive_int(input_str: str) -> int:
     return i
 
 
-def run_worker(cpu: int, args: argparse.Namespace, queue: multiprocessing.Queue[Definition]) -> None:
+def run_worker(cpu: int, args: argparse.Namespace, queue: multiprocessing.Queue) -> None:
     """
     Executes the algorithm based on the provided parameters.
 

--- a/ann_benchmarks/main.py
+++ b/ann_benchmarks/main.py
@@ -71,7 +71,7 @@ def run_worker(cpu: int, args: argparse.Namespace, queue: multiprocessing.Queue)
         else:
             memory_margin = 500e6  # reserve some extra memory for misc stuff
             mem_limit = int((psutil.virtual_memory().available - memory_margin) / args.parallelism)
-            cpu_limit = str(cpu) if not args.batch else f"0-3" # {multiprocessing.cpu_count() - 1}"
+            cpu_limit = str(cpu) if not args.batch else f"0-{multiprocessing.cpu_count() - 1}"
             
             run_docker(definition, args.dataset, args.count, args.runs, args.timeout, args.batch, cpu_limit, mem_limit)
 

--- a/ann_benchmarks/results.py
+++ b/ann_benchmarks/results.py
@@ -2,14 +2,33 @@ import json
 import os
 import re
 import traceback
-
+from typing import Any, Optional, Set, Tuple, Iterator
 import h5py
 
+from ann_benchmarks.definitions import Definition
 
-def get_result_filename(dataset=None, count=None, definition=None, query_arguments=None, batch_mode=False):
+
+def build_result_filepath(dataset_name: Optional[str] = None, 
+                          count: Optional[int] = None, 
+                          definition: Optional[Definition] = None, 
+                          query_arguments: Optional[Any] = None, 
+                          batch_mode: bool = False) -> str:
+    """
+    Constructs the filepath for storing the results.
+
+    Args:
+        dataset_name (str, optional): The name of the dataset.
+        count (int, optional): The count of records.
+        definition (Definition, optional): The definition of the algorithm.
+        query_arguments (Any, optional): Additional arguments for the query.
+        batch_mode (bool, optional): If True, the batch mode is activated.
+
+    Returns:
+        str: The constructed filepath.
+    """
     d = ["results"]
-    if dataset:
-        d.append(dataset)
+    if dataset_name:
+        d.append(dataset_name)
     if count:
         d.append(str(count))
     if definition:
@@ -19,42 +38,74 @@ def get_result_filename(dataset=None, count=None, definition=None, query_argumen
     return os.path.join(*d)
 
 
-def store_results(dataset, count, definition, query_arguments, attrs, results, batch):
-    fn = get_result_filename(dataset, count, definition, query_arguments, batch)
-    head, tail = os.path.split(fn)
-    if not os.path.isdir(head):
-        os.makedirs(head)
-    f = h5py.File(fn, "w")
-    for k, v in attrs.items():
-        f.attrs[k] = v
-    times = f.create_dataset("times", (len(results),), "f")
-    neighbors = f.create_dataset("neighbors", (len(results), count), "i")
-    distances = f.create_dataset("distances", (len(results), count), "f")
-    for i, (time, ds) in enumerate(results):
-        times[i] = time
-        neighbors[i] = [n for n, d in ds] + [-1] * (count - len(ds))
-        distances[i] = [d for n, d in ds] + [float("inf")] * (count - len(ds))
-    f.close()
+def store_results(dataset_name: str, count: int, definition: Definition, query_arguments:Any, attrs, results, batch):
+    """
+    Stores results for an algorithm (and hyperparameters) running against a dataset in a HDF5 file.
+
+    Args:
+        dataset_name (str): The name of the dataset.
+        count (int): The count of records.
+        definition (Definition): The definition of the algorithm.
+        query_arguments (Any): Additional arguments for the query.
+        attrs (dict): Attributes to be stored in the file.
+        results (list): Results to be stored.
+        batch (bool): If True, the batch mode is activated.
+    """
+    filename = build_result_filepath(dataset_name, count, definition, query_arguments, batch)
+    directory, _ = os.path.split(filename)
+
+    if not os.path.isdir(directory):
+        os.makedirs(directory)
+
+    with h5py.File(filename, "w") as f:
+        for k, v in attrs.items():
+            f.attrs[k] = v
+        times = f.create_dataset("times", (len(results),), "f")
+        neighbors = f.create_dataset("neighbors", (len(results), count), "i")
+        distances = f.create_dataset("distances", (len(results), count), "f")
+        
+        for i, (time, ds) in enumerate(results):
+            times[i] = time
+            neighbors[i] = [n for n, d in ds] + [-1] * (count - len(ds))
+            distances[i] = [d for n, d in ds] + [float("inf")] * (count - len(ds))
 
 
-def load_all_results(dataset=None, count=None, batch_mode=False):
-    for root, _, files in os.walk(get_result_filename(dataset, count)):
-        for fn in files:
-            if os.path.splitext(fn)[-1] != ".hdf5":
+def load_all_results(dataset: Optional[str] = None, 
+                 count: Optional[int] = None, 
+                 batch_mode: bool = False) -> Iterator[Tuple[dict, h5py.File]]:
+    """
+    Loads all the results from the HDF5 files in the specified path.
+
+    Args:
+        dataset (str, optional): The name of the dataset.
+        count (int, optional): The count of records.
+        batch_mode (bool, optional): If True, the batch mode is activated.
+
+    Yields:
+        tuple: A tuple containing properties as a dictionary and an h5py file object.
+    """
+    for root, _, files in os.walk(build_result_filepath(dataset, count)):
+        for filename in files:
+            if os.path.splitext(filename)[-1] != ".hdf5":
                 continue
             try:
-                f = h5py.File(os.path.join(root, fn), "r+")
-                properties = dict(f.attrs)
-                if batch_mode != properties["batch_mode"]:
-                    continue
-                yield properties, f
-                f.close()
-            except:
-                print("Was unable to read", fn)
+                with h5py.File(os.path.join(root, filename), "r+") as f:
+                    properties = dict(f.attrs)
+                    if batch_mode != properties["batch_mode"]:
+                        continue
+                    yield properties, f
+            except Exception:
+                print(f"Was unable to read {filename}")
                 traceback.print_exc()
 
 
-def get_unique_algorithms():
+def get_unique_algorithms() -> Set[str]:
+    """
+    Retrieves unique algorithm names from the results.
+
+    Returns:
+        set: A set of unique algorithm names.
+    """
     algorithms = set()
     for batch_mode in [False, True]:
         for properties, _ in load_all_results(batch_mode=batch_mode):

--- a/ann_benchmarks/runner.py
+++ b/ann_benchmarks/runner.py
@@ -4,12 +4,14 @@ import logging
 import os
 import threading
 import time
-import traceback
+from typing import Dict, Optional, Tuple, List, Union
 
 import colors
 import docker
 import numpy
 import psutil
+
+from ann_benchmarks.algorithms.base.module import BaseANN
 
 from .definitions import Definition, instantiate_algorithm
 from .datasets import DATASETS, get_dataset
@@ -17,7 +19,22 @@ from .distance import dataset_transform, metrics
 from .results import store_results
 
 
-def run_individual_query(algo, X_train, X_test, distance, count, run_count, batch):
+def run_individual_query(algo: BaseANN, X_train: numpy.array, X_test: numpy.array, distance: str, count: int, 
+                         run_count: int, batch: bool) -> Tuple[dict, list]:
+    """Run a search query using the provided algorithm and report the results.
+
+    Args:
+        algo (BaseANN): An instantiated ANN algorithm.
+        X_train (numpy.array): The training data.
+        X_test (numpy.array): The testing data.
+        distance (str): The type of distance metric to use.
+        count (int): The number of nearest neighbors to return.
+        run_count (int): The number of times to run the query.
+        batch (bool): Flag to indicate whether to run in batch mode or not.
+
+    Returns:
+        tuple: A tuple with the attributes of the algorithm run and the results.
+    """
     prepared_queries = (batch and hasattr(algo, "prepare_batch_query")) or (
         (not batch) and hasattr(algo, "prepare_query")
     )
@@ -28,7 +45,17 @@ def run_individual_query(algo, X_train, X_test, distance, count, run_count, batc
         # a bit dumb but can't be a scalar since of Python's scoping rules
         n_items_processed = [0]
 
-        def single_query(v):
+        def single_query(v: numpy.array) -> Tuple[float, List[Tuple[int, float]]]:
+            """Executes a single query on an instantiated, ANN algorithm.
+
+            Args:
+                v (numpy.array): Vector to query.
+
+            Returns:
+                List[Tuple[float, List[Tuple[int, float]]]]: Tuple containing
+                    1. Total time taken for each query 
+                    2. Result pairs consisting of (point index, distance to candidate data )
+            """
             if prepared_queries:
                 algo.prepare_query(v, count)
                 start = time.time()
@@ -40,7 +67,7 @@ def run_individual_query(algo, X_train, X_test, distance, count, run_count, batc
                 candidates = algo.query(v, count)
                 total = time.time() - start
             candidates = [
-                (int(idx), float(metrics[distance]["distance"](v, X_train[idx]))) for idx in candidates  # noqa
+                (int(idx), float(metrics[distance].distance(v, X_train[idx]))) for idx in candidates  # noqa
             ]
             n_items_processed[0] += 1
             if n_items_processed[0] % 1000 == 0:
@@ -52,7 +79,18 @@ def run_individual_query(algo, X_train, X_test, distance, count, run_count, batc
                 )
             return (total, candidates)
 
-        def batch_query(X):
+        def batch_query(X: numpy.array) -> List[Tuple[float, List[Tuple[int, float]]]]:
+            """Executes a batch of queries on an instantiated, ANN algorithm.
+
+            Args:
+                X (numpy.array): Array containing multiple vectors to query.
+
+            Returns:
+                List[Tuple[float, List[Tuple[int, float]]]]: List of tuples, each containing
+                    1. Total time taken for each query 
+                    2. Result pairs consisting of (point index, distance to candidate data )
+            """
+            # TODO: consider using a dataclass to represent return value.
             if prepared_queries:
                 algo.prepare_batch_query(X, count)
                 start = time.time()
@@ -64,7 +102,7 @@ def run_individual_query(algo, X_train, X_test, distance, count, run_count, batc
                 total = time.time() - start
             results = algo.get_batch_results()
             candidates = [
-                [(int(idx), float(metrics[distance]["distance"](v, X_train[idx]))) for idx in single_results]  # noqa
+                [(int(idx), float(metrics[distance].distance(v, X_train[idx]))) for idx in single_results]  # noqa
                 for v, single_results in zip(X, results)
             ]
             return [(total / float(len(X)), v) for v in candidates]
@@ -97,61 +135,101 @@ def run_individual_query(algo, X_train, X_test, distance, count, run_count, batc
     return (attrs, results)
 
 
-def run(definition, dataset, count, run_count, batch):
-    algo = instantiate_algorithm(definition)
-    assert not definition.query_argument_groups or hasattr(
-        algo, "set_query_arguments"
-    ), """\
-error: query argument groups have been specified for %s.%s(%s), but the \
-algorithm instantiated from it does not implement the set_query_arguments \
-function""" % (
-        definition.module,
-        definition.constructor,
-        definition.arguments,
-    )
+def load_and_transform_dataset(dataset_name: str) -> Tuple[
+        Union[numpy.ndarray, List[numpy.ndarray]],
+        Union[numpy.ndarray, List[numpy.ndarray]],
+        str]:
+    """Loads and transforms the dataset.
 
-    D, dimension = get_dataset(dataset)
+    Args:
+        dataset_name (str): The name of the dataset.
+
+    Returns:
+        Tuple: Transformed datasets.
+    """
+    D, dimension = get_dataset(dataset_name)
     X_train = numpy.array(D["train"])
     X_test = numpy.array(D["test"])
     distance = D.attrs["distance"]
-    print("got a train set of size (%d * %d)" % (X_train.shape[0], dimension))
-    print("got %d queries" % len(X_test))
 
-    X_train, X_test = dataset_transform(D)
+    print(f"Got a train set of size ({X_train.shape[0]} * {dimension})")
+    print(f"Got {len(X_test)} queries")
+
+    return dataset_transform(D), distance
+
+
+def build_index(algo: BaseANN, X_train: numpy.ndarray) -> Tuple:
+    """Builds the ANN index for a given ANN algorithm on the training data.
+
+    Args:
+        algo (Any): The algorithm instance.
+        X_train (Any): The training data.
+
+    Returns:
+        Tuple: The build time and index size.
+    """
+    t0 = time.time()
+    memory_usage_before = algo.get_memory_usage()
+    algo.fit(X_train)
+    build_time = time.time() - t0
+    index_size = algo.get_memory_usage() - memory_usage_before
+
+    print("Built index in", build_time)
+    print("Index size: ", index_size)
+
+    return build_time, index_size
+
+
+def run(definition: Definition, dataset_name: str, count: int, run_count: int, batch: bool) -> None:
+    """Run the algorithm benchmarking.
+
+    Args:
+        definition (Definition): The algorithm definition.
+        dataset_name (str): The name of the dataset.
+        count (int): The number of results to return.
+        run_count (int): The number of runs.
+        batch (bool): If true, runs in batch mode.
+    """
+    algo = instantiate_algorithm(definition)
+    assert not definition.query_argument_groups or hasattr(
+        algo, "set_query_arguments"
+    ), f"""\
+error: query argument groups have been specified for {definition.module}.{definition.constructor}({definition.arguments}), but the \
+algorithm instantiated from it does not implement the set_query_arguments \
+function"""
+
+    X_train, X_test, distance = load_and_transform_dataset(dataset_name)
 
     try:
         if hasattr(algo, "supports_prepared_queries"):
             algo.supports_prepared_queries()
 
-        t0 = time.time()
-        memory_usage_before = algo.get_memory_usage()
-        algo.fit(X_train)
-        build_time = time.time() - t0
-        index_size = algo.get_memory_usage() - memory_usage_before
-        print("Built index in", build_time)
-        print("Index size: ", index_size)
+        build_time, index_size = build_index(algo, X_train)
 
-        query_argument_groups = definition.query_argument_groups
-        # Make sure that algorithms with no query argument groups still get run
-        # once by providing them with a single, empty, harmless group
-        if not query_argument_groups:
-            query_argument_groups = [[]]
+        query_argument_groups = definition.query_argument_groups or [[]]  # Ensure at least one iteration
 
         for pos, query_arguments in enumerate(query_argument_groups, 1):
-            print("Running query argument group %d of %d..." % (pos, len(query_argument_groups)))
+            print(f"Running query argument group {pos} of {len(query_argument_groups)}...")
             if query_arguments:
                 algo.set_query_arguments(*query_arguments)
+            
             descriptor, results = run_individual_query(algo, X_train, X_test, distance, count, run_count, batch)
-            descriptor["build_time"] = build_time
-            descriptor["index_size"] = index_size
-            descriptor["algo"] = definition.algorithm
-            descriptor["dataset"] = dataset
-            store_results(dataset, count, definition, query_arguments, descriptor, results, batch)
+
+            descriptor.update({
+                "build_time": build_time,
+                "index_size": index_size,
+                "algo": definition.algorithm,
+                "dataset": dataset_name
+            })
+
+            store_results(dataset_name, count, definition, query_arguments, descriptor, results, batch)
     finally:
         algo.done()
 
-
 def run_from_cmdline():
+    """Calls the function `run` using arguments from the command line. See `ArgumentParser` for 
+    arguments, all run it with `--help`.
+    """
     parser = argparse.ArgumentParser(
         """
 
@@ -182,6 +260,7 @@ def run_from_cmdline():
     parser.add_argument("build", help='JSON of arguments to pass to the constructor. E.g. ["angular", 100]')
     parser.add_argument("queries", help="JSON of arguments to pass to the queries. E.g. [100]", nargs="*", default=[])
     args = parser.parse_args()
+
     algo_args = json.loads(args.build)
     print(algo_args)
     query_args = [json.loads(q) for q in args.queries]
@@ -198,7 +277,20 @@ def run_from_cmdline():
     run(definition, args.dataset, args.count, args.runs, args.batch)
 
 
-def run_docker(definition, dataset, count, runs, timeout, batch, cpu_limit, mem_limit=None):
+def run_docker(
+    definition: Definition,
+    dataset: str,
+    count: int,
+    runs: int,
+    timeout: int,
+    batch: bool,
+    cpu_limit: str,
+    mem_limit: Optional[int] = None
+) -> None:
+    """Runs `run_from_cmdline` within a Docker container with specified parameters and logs the output.
+
+    See `run_from_cmdline` for details on the args.
+    """
     cmd = [
         "--dataset",
         dataset,
@@ -251,24 +343,40 @@ def run_docker(definition, dataset, count, runs, timeout, batch, cpu_limit, mem_
     try:
         return_value = container.wait(timeout=timeout)
         _handle_container_return_value(return_value, container, logger)
-    except:
-        logger.error("Container.wait for container %s failed with exception" % container.short_id)
-        traceback.print_exc()
+    except Exception as e:
+        logger.error("Container.wait for container %s failed with exception", container.short_id)
+        logger.error(str(e))
     finally:
         logger.info("Removing container")
         container.remove(force=True)
 
 
-def _handle_container_return_value(return_value, container, logger):
-    base_msg = "Child process for container %s" % (container.short_id)
-    if type(return_value) is dict:  # The return value from container.wait changes from int to dict in docker 3.0.0
-        error_msg = return_value.get("Error")
+def _handle_container_return_value(
+    return_value: Union[Dict[str, Union[int, str]], int],
+    container: docker.models.containers.Container,
+    logger: logging.Logger
+) -> None:
+    """Handles the return value of a Docker container and outputs error and stdout messages (with colour).
+
+    Args:
+        return_value (Union[Dict[str, Union[int, str]], int]): The return value of the container.
+        container (docker.models.containers.Container): The Docker container.
+        logger (logging.Logger): The logger instance.
+    """
+
+    base_msg = f"Child process for container {container.short_id} "
+    msg = base_msg + "returned exit code {}"
+
+    if isinstance(return_value, dict):  # The return value from container.wait changes from int to dict in docker 3.0.0
+        error_msg = return_value.get("Error", "")
         exit_code = return_value["StatusCode"]
-        msg = base_msg + "returned exit code %d with message %s" % (exit_code, error_msg)
+        msg = msg.format(f"{exit_code} with message {error_msg}")
     else:
         exit_code = return_value
-        msg = base_msg + "returned exit code %d" % (exit_code)
+        msg = msg.format(exit_code)
 
     if exit_code not in [0, None]:
         logger.error(colors.color(container.logs().decode(), fg="red"))
         logger.error(msg)
+    else:
+        logger.info(msg)

--- a/ann_benchmarks/runner.py
+++ b/ann_benchmarks/runner.py
@@ -155,7 +155,8 @@ def load_and_transform_dataset(dataset_name: str) -> Tuple[
     print(f"Got a train set of size ({X_train.shape[0]} * {dimension})")
     print(f"Got {len(X_test)} queries")
 
-    return dataset_transform(D), distance
+    train, test = dataset_transform(D)
+    return train, test, distance
 
 
 def build_index(algo: BaseANN, X_train: numpy.ndarray) -> Tuple:

--- a/test/distance_test.py
+++ b/test/distance_test.py
@@ -6,7 +6,7 @@ from ann_benchmarks.distance import metrics
 
 
 def test_euclidean():
-    dist = metrics["euclidean"]["distance"]
+    dist = metrics["euclidean"].distance
 
     p = numpy.array([0, 1, 0])
     q = numpy.array([2, 0, 0])
@@ -14,7 +14,7 @@ def test_euclidean():
 
 
 def test_hamming():
-    dist = metrics["hamming"]["distance"]
+    dist = metrics["hamming"].distance
 
     p = numpy.array([1, 1, 0, 0], dtype=numpy.bool_)
     q = numpy.array([1, 0, 0, 1], dtype=numpy.bool_)
@@ -26,7 +26,7 @@ def test_hamming():
 
 
 def test_angular():
-    dist = metrics["angular"]["distance"]
+    dist = metrics["angular"].distance
 
     # We use 1 - cos as the angular distance
 
@@ -47,7 +47,7 @@ def test_angular_dataset():
     # Make sure distances in the datasets are calculated consistent with the definitions
     # This is to avoid issues like #367
 
-    dist_f = metrics["angular"]["distance"]
+    dist_f = metrics["angular"].distance
 
     hdf5_f, n_dims = get_dataset("glove-25-angular")
 


### PR DESCRIPTION
## Changeset
 - Add typing to functions
 - Add docstrings to most functions
 - Change `Definition` from a `collections.namedtuple` to a `dataclass`
 - Simplify `ann_benchmarks.definitions.create_definitions_from_algorithm` by decomposing into separate functions.
 - Create a named tuple for Metric
    ```python
    class Metric(NamedTuple):
        distance: Callable[[np.ndarray, np.ndarray], float]
        distance_valid: Callable[[float], bool]
    ```
 - Simplify main function  in `ann_benchmarks/main.py` by moving filter functions (e.g. `filter_disabled_algorithms`) to separate python functions.
- NOTE: The above refactors should not alter the underlying logic of ann-benchmarks. 

## Motivation
I started working on specific changes to ann-benchmarks (e.g. adding new ANN algorithms, extending ann-benchmarks to be used as a performance testing library), and found the codebase hard to understand as a new user. This PR attempts to make the codebase easier to understand and well documented. 

