### PR TITLE
feat: Calculate latency for each batch instead of just using the average for all queries

### DIFF
--- a/ann_benchmarks/definitions.py
+++ b/ann_benchmarks/definitions.py
@@ -33,7 +33,7 @@ class InstantiationStatus(Enum):
 
 def algorithm_status(definition):
     try:
-        module = importlib.import_module(definition.module)
+        module = importlib.import_module(definition.module + '.module')
         if hasattr(module, definition.constructor):
             return InstantiationStatus.AVAILABLE
         else:

--- a/ann_benchmarks/runner.py
+++ b/ann_benchmarks/runner.py
@@ -63,11 +63,15 @@ def run_individual_query(algo, X_train, X_test, distance, count, run_count, batc
                 algo.batch_query(X, count)
                 total = time.time() - start
             results = algo.get_batch_results()
+            if hasattr(algo, "get_batch_latencies"):
+                batch_latencies = algo.get_batch_latencies()
+            else:
+                batch_latencies = [total / float(len(X))] * len(X)
             candidates = [
                 [(int(idx), float(metrics[distance]["distance"](v, X_train[idx]))) for idx in single_results]  # noqa
                 for v, single_results in zip(X, results)
             ]
-            return [(total / float(len(X)), v) for v in candidates]
+            return [(latency, v) for latency, v in zip(batch_latencies, candidates)]
 
         if batch:
             results = batch_query(X_test)


### PR DESCRIPTION
We should calculate latency for each batch instead of just using the average because it will be more precise. At the moment, all "times" values are the same as the average which really defeats the purpose of p99 and p95 values. 

Plus, I noticed a bug while running with `--batch --local`. All the algorithms have been refactored to have a `module.py` but the runner wasn't updated accordingly which makes it fail when running it locally with batches. To keep the change minimal I just modified `definitions.py` instead of all the config files.

I just did this for Qdrant right now but can do it for others as well once this PR is approved and merged :)

Also, thanks for creating/maintaining this repo. Really great work! 