### PR TITLE
feat: Add new dataset with OpenAI  embeddings for 1M DBpedia entities

### DIFF
--- a/ann_benchmarks/datasets.py
+++ b/ann_benchmarks/datasets.py
@@ -475,16 +475,18 @@ def movielens10m(out_fn):
 def movielens20m(out_fn):
     movielens("ml-20m.zip", "ml-20m/ratings.csv", out_fn, ",", True)
 
-def dbpedia_entities_openai_1M(out_fn):
+def dbpedia_entities_openai_1M(out_fn, n = None):
     from sklearn.model_selection import train_test_split
     from datasets import load_dataset
     import numpy as np
 
     data = load_dataset("KShivendu/dbpedia-entities-openai-1M", split="train")
+    if n is not None and n >= 100_000:
+        data = data.select(range(n))
 
     embeddings = data.to_pandas()['openai'].to_numpy()
     embeddings = np.vstack(embeddings).reshape((-1, 1536))
-    
+
     X_train, X_test = train_test_split(embeddings, test_size=10_000, random_state=42)
 
     write_output(X_train, X_test, out_fn, "angular")
@@ -520,3 +522,8 @@ DATASETS = {
     "movielens20m-jaccard": movielens20m,
     "openai-dbpedia1m-1536-angular": dbpedia_entities_openai_1M,
 }
+
+DATASETS.update({
+    f"dbpedia-openai-{n//1000}k-angular": lambda out_fn: dbpedia_entities_openai_1M(out_fn, n)
+    for n in range(100_000, 1_100_000, 100_000)
+})

--- a/ann_benchmarks/datasets.py
+++ b/ann_benchmarks/datasets.py
@@ -520,7 +520,6 @@ DATASETS = {
     "movielens1m-jaccard": movielens1m,
     "movielens10m-jaccard": movielens10m,
     "movielens20m-jaccard": movielens20m,
-    "openai-dbpedia1m-1536-angular": dbpedia_entities_openai_1M,
 }
 
 DATASETS.update({

--- a/ann_benchmarks/datasets.py
+++ b/ann_benchmarks/datasets.py
@@ -476,6 +476,7 @@ def movielens20m(out_fn):
     movielens("ml-20m.zip", "ml-20m/ratings.csv", out_fn, ",", True)
 
 def dbpedia_entities_openai_1M(out_fn):
+    from sklearn.model_selection import train_test_split
     from datasets import load_dataset
     import numpy as np
 
@@ -483,11 +484,8 @@ def dbpedia_entities_openai_1M(out_fn):
 
     embeddings = data.to_pandas()['openai'].to_numpy()
     embeddings = np.vstack(embeddings).reshape((-1, 1536))
-
-    TEST_SIZE = 10_000
-
-    X_train = embeddings[TEST_SIZE:]
-    X_test = embeddings[:TEST_SIZE] # Take the first 10k as test set
+    
+    X_train, X_test = train_test_split(embeddings, test_size=10_000, random_state=42)
 
     write_output(X_train, X_test, out_fn, "angular")
 

--- a/ann_benchmarks/datasets.py
+++ b/ann_benchmarks/datasets.py
@@ -475,6 +475,22 @@ def movielens10m(out_fn):
 def movielens20m(out_fn):
     movielens("ml-20m.zip", "ml-20m/ratings.csv", out_fn, ",", True)
 
+def dbpedia_entities_openai_1M(out_fn):
+    from datasets import load_dataset
+    import numpy as np
+
+    data = load_dataset("KShivendu/dbpedia-entities-openai-1M", split="train")
+
+    embeddings = data.to_pandas()['openai'].to_numpy()
+    embeddings = np.vstack(embeddings).reshape((-1, 1536))
+
+    TEST_SIZE = 10_000
+
+    X_train = embeddings[TEST_SIZE:]
+    X_test = embeddings[:TEST_SIZE] # Take the first 10k as test set
+
+    write_output(X_train, X_test, out_fn, "angular")
+
 
 DATASETS = {
     "deep-image-96-angular": deep_image,
@@ -504,4 +520,5 @@ DATASETS = {
     "movielens1m-jaccard": movielens1m,
     "movielens10m-jaccard": movielens10m,
     "movielens20m-jaccard": movielens20m,
+    "openai-dbpedia1m-1536-angular": dbpedia_entities_openai_1M,
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ psutil==5.9.4
 scikit-learn==1.2.1
 jinja2==3.1.2
 pytest==7.2.2
+datasets==2.12.0


### PR DESCRIPTION
Add a new dataset with OpenAI embeddings for DBpedia entities.

This PR also introduces HuggingFace [datasets library](https://github.com/huggingface/datasets) which can help with loading any dataset on HuggingFace. This makes it easier for anyone to fork and benchmark against almost any public dataset :)

