### PR TITLE
Custom runners (singularity/slurm/...)

### DIFF
--- a/ann_benchmarks/algorithms/base/Dockerfile
+++ b/ann_benchmarks/algorithms/base/Dockerfile
@@ -8,5 +8,3 @@ RUN python3 --version | grep 'Python 3.10.6'
 WORKDIR /home/app
 COPY requirements.txt run_algorithm.py ./
 RUN pip3 install -r requirements.txt
-
-ENTRYPOINT ["python3", "-u", "run_algorithm.py"]

--- a/ann_benchmarks/runner.py
+++ b/ann_benchmarks/runner.py
@@ -2,6 +2,8 @@ import argparse
 import json
 import logging
 import os
+import re
+from string import Template
 import threading
 import time
 from typing import Dict, Optional, Tuple, List, Union
@@ -19,7 +21,7 @@ from .distance import dataset_transform, metrics
 from .results import store_results
 
 
-def run_individual_query(algo: BaseANN, X_train: numpy.array, X_test: numpy.array, distance: str, count: int, 
+def run_individual_query(algo: BaseANN, X_train: numpy.array, X_test: numpy.array, distance: str, count: int,
                          run_count: int, batch: bool) -> Tuple[dict, list]:
     """Run a search query using the provided algorithm and report the results.
 
@@ -53,7 +55,7 @@ def run_individual_query(algo: BaseANN, X_train: numpy.array, X_test: numpy.arra
 
             Returns:
                 List[Tuple[float, List[Tuple[int, float]]]]: Tuple containing
-                    1. Total time taken for each query 
+                    1. Total time taken for each query
                     2. Result pairs consisting of (point index, distance to candidate data )
             """
             if prepared_queries:
@@ -87,7 +89,7 @@ def run_individual_query(algo: BaseANN, X_train: numpy.array, X_test: numpy.arra
 
             Returns:
                 List[Tuple[float, List[Tuple[int, float]]]]: List of tuples, each containing
-                    1. Total time taken for each query 
+                    1. Total time taken for each query
                     2. Result pairs consisting of (point index, distance to candidate data )
             """
             # TODO: consider using a dataclass to represent return value.
@@ -213,7 +215,7 @@ function"""
             print(f"Running query argument group {pos} of {len(query_argument_groups)}...")
             if query_arguments:
                 algo.set_query_arguments(*query_arguments)
-            
+
             descriptor, results = run_individual_query(algo, X_train, X_test, distance, count, run_count, batch)
 
             descriptor.update({
@@ -227,8 +229,44 @@ function"""
     finally:
         algo.done()
 
+def run_custom(cmd_template: str, definition: str, algo: str, container_tag: str,
+               dataset_name: str, count: int, runs: int, batch: bool, force: bool) -> None:
+    """Run the algorithm benchmarking with a custom runner specified by `cmd_template`.
+
+    Args:
+        cmd_template (str): A templated custom runner string.
+        definition (str): The algorithm definition.
+        algo (str): The name of the algorithm.
+        container_tag (str): A reference to the original docker container.
+        dataset_name (str): The name of the dataset.
+        count (int): The number of results to return.
+        runs (int): The number of runs.
+        batch (bool): If true, runs in batch mode.
+        force (bool): If true, overwrite existing results.
+    """
+    template = Template(cmd_template)
+    cmd = template.safe_substitute(algo=re.escape(algo),
+        container=container_tag,
+        definition=definition,
+        ds=dataset_name,
+        )
+
+    additional_cmd = [
+        cmd,
+        "--runs",
+        str(runs),
+        "--count",
+        str(count),
+    ]
+    if batch:
+        additional_cmd += ["--batch"]
+    if force:
+        additional_cmd += ["--force"]
+
+    os.system(" ".join(additional_cmd))
+
 def run_from_cmdline():
-    """Calls the function `run` using arguments from the command line. See `ArgumentParser` for 
+    """Calls the function `run` using arguments from the command line. See `ArgumentParser` for
     arguments, all run it with `--help`.
     """
     parser = argparse.ArgumentParser(

--- a/ann_benchmarks/runner.py
+++ b/ann_benchmarks/runner.py
@@ -245,14 +245,8 @@ def run_custom(cmd_template: str, definition: str, algo: str, container_tag: str
         force (bool): If true, overwrite existing results.
     """
     template = Template(cmd_template)
-    cmd = template.safe_substitute(algo=re.escape(algo),
-        container=container_tag,
-        definition=definition,
-        ds=dataset_name,
-        )
 
     additional_cmd = [
-        cmd,
         "--runs",
         str(runs),
         "--count",
@@ -263,7 +257,17 @@ def run_custom(cmd_template: str, definition: str, algo: str, container_tag: str
     if force:
         additional_cmd += ["--force"]
 
-    os.system(" ".join(additional_cmd))
+    additional_cmd = " ".join(additional_cmd)
+
+    cmd = template.safe_substitute(
+        additional=additional_cmd,
+        algo=re.escape(algo),
+        container=container_tag,
+        definition=definition,
+        ds=dataset_name,
+        )
+
+    os.system(cmd)
 
 def run_from_cmdline():
     """Calls the function `run` using arguments from the command line. See `ArgumentParser` for
@@ -331,6 +335,9 @@ def run_docker(
     See `run_from_cmdline` for details on the args.
     """
     cmd = [
+        "python3",
+        "-u",
+        "run_algorithm.py",
         "--dataset",
         dataset,
         "--algorithm",

--- a/templates/custom_runner/convert_docker_to_singularity.py
+++ b/templates/custom_runner/convert_docker_to_singularity.py
@@ -1,0 +1,9 @@
+import docker
+import os
+
+docker_client = docker.from_env()
+docker_tags = {tag.split(":")[0] for image in docker_client.images.list() for tag in image.tags}
+for tag in [tag for tag in docker_tags if tag.startswith("ann-benchmarks-")]:
+	os.system(f'docker save {tag} -o {tag}.tar')
+	os.system(f'singularity build {tag}.sif docker-archive://{tag}.tar')
+	os.system(f'rm {tag}.tar')

--- a/templates/custom_runner/singularity.template
+++ b/templates/custom_runner/singularity.template
@@ -10,4 +10,4 @@ if [ ! -f "$CONTAINER" ]; then
     echo "$CONTAINER does not exist"
     exit 1
 fi
-singularity run -B /run/shm:/run/shm $CONTAINER python3 -u run.py --dataset $ds --algorithm $algo --runs 1 --local --definition $definition
+singularity run -B /run/shm:/run/shm $CONTAINER python3 -u run.py --dataset $ds --algorithm $algo --runs 1 --local --definition $definition $additional

--- a/templates/custom_runner/slurm.template
+++ b/templates/custom_runner/slurm.template
@@ -1,0 +1,14 @@
+# example slurm run using singularity
+# docker images must be converted to singularity containers
+# e.g., `docker save ann-benchmarks-$algo -o ann-benchmarks-$algo.tar, and
+# `singularity build ann-benchmarks-$algo.sif docker-archive://ann-benchmarks-$algo.tar` 
+
+# need to provide $algo, $container, $ds, $definition, $additional.
+
+CONTAINER=$container.sif
+if [ ! -f "$CONTAINER" ]; then
+    echo "$CONTAINER does not exist"
+    exit 1
+fi
+
+sbatch -J $algo-$ds -o log-$ds-$algo.log  --cpus-per-task=1 --time=01:59:59 --partition=red --wrap="singularity run $CONTAINER python3 -u run.py --dataset $ds --algorithm $algo --local --runs 1 --definition $definition $additional"

--- a/templates/custom_runner_singularity.template
+++ b/templates/custom_runner_singularity.template
@@ -1,0 +1,13 @@
+# example singularity run
+# docker images must be converted to singularity containers
+# e.g., `docker save ann-benchmarks-$algo -o ann-benchmarks-$algo.tar, and
+# `singularity build ann-benchmarks-$algo.sif docker-archive://ann-benchmarks-$algo.tar` 
+
+# need to provide $algo, $container, $ds, $definition, nothing else is exposed.
+
+CONTAINER=$container.sif
+if [ ! -f "$CONTAINER" ]; then
+    echo "$CONTAINER does not exist"
+    exit 1
+fi
+singularity run -B /run/shm:/run/shm $CONTAINER python3 -u run.py --dataset $ds --algorithm $algo --runs 1 --local --definition $definition


### PR DESCRIPTION
This PR makes it possible to specify custom runners to run ann-benchmarks in containerized, non-Docker environments. My use case is that I (and many others) have to use SLURM on an hpc cluster to run jobs. The current setup doesn't allow me to work with ann-benchmarks at all because docker is usually not supported in these environments.

My solution is a bit hacky: 

1. All docker containers are converted to singularity images (`python templates/custom_runners/convert_docker_to_singularity.py`) in a local setup that supports docker. 
2. All images are moved to the hpc cluster. 
3. Set up ann-benchmarks in the usual way, but skip the installation step for the libraries. Interface-wise, jobs are run in the usual way but through the custom runner, e.g.,  `python3 run.py --dataset random-xs-20-euclidean --custom-container templates/custom_runner/slurm.template`.

This works great for me, but I'd love to hear some thoughts on improving this solution.