### PR TITLE
Get correct index size for pgvector

### DIFF
--- a/ann_benchmarks/algorithms/pgvector/module.py
+++ b/ann_benchmarks/algorithms/pgvector/module.py
@@ -55,5 +55,11 @@ class PGVector(BaseANN):
         self._cur.execute(self._query, (v, n), binary=True, prepare=True)
         return [id for id, in self._cur.fetchall()]
 
+    def get_memory_usage(self):
+        if self._cur is None:
+            return 0
+        self._cur.execute("SELECT pg_relation_size('items_embedding_idx')")
+        return self._cur.fetchone()[0] / 1024
+
     def __str__(self):
         return f"PGVector(lists={self._lists}, probes={self._probes})"


### PR DESCRIPTION
The size of the pgvector index comes from data stored in PostgreSQL; its not available in the memory context that the index is built in. This defines an ad hoc "get_memory_usage" function that lets the pgvector test load the size of the created index from the database.