### PR TITLE
Fix dbpedia-openai-*k-angular datasets

### DIFF
--- a/ann_benchmarks/datasets.py
+++ b/ann_benchmarks/datasets.py
@@ -601,6 +601,6 @@ DATASETS: Dict[str, Callable[[str], None]] = {
 }
 
 DATASETS.update({
-    f"dbpedia-openai-{n//1000}k-angular": lambda out_fn: dbpedia_entities_openai_1M(out_fn, n)
+    f"dbpedia-openai-{n//1000}k-angular": lambda out_fn, i=n: dbpedia_entities_openai_1M(out_fn, i)
     for n in range(100_000, 1_100_000, 100_000)
 })


### PR DESCRIPTION
The current code generates datasets that are all 1M rows instead of the intended number.

https://stackoverflow.com/questions/6076270/lambda-function-in-list-comprehensions