### PR TITLE
Update vearch Dockerfile: pin vearch version to 3.2.8.3 in Dockerfile

### DIFF
--- a/ann_benchmarks/algorithms/vearch/Dockerfile
+++ b/ann_benchmarks/algorithms/vearch/Dockerfile
@@ -1,4 +1,4 @@
 FROM ann-benchmarks
 
-RUN pip3 install vearch
+RUN pip3 install vearch==3.2.8.3
 RUN python3 -c 'import vearch'


### PR DESCRIPTION
This commit addresses potential compatibility issues by explicitly specifying the version of the vearch library as 3.2.8.3 in the Dockerfile. Without version pinning, the lack of a specified version could lead to interface incompatibilities with future updates. By specifying the version, we ensure a stable and known state of the vearch library, reducing the risk of unexpected errors due to incompatible changes in future releases.