### PR TITLE
Disable algorithms throwing error (`luceneknn` and `pgvector`)

### DIFF
--- a/ann_benchmarks/algorithms/luceneknn/config.yml
+++ b/ann_benchmarks/algorithms/luceneknn/config.yml
@@ -2,7 +2,7 @@ float:
   any:
   - base_args: ['@metric', '@dimension']
     constructor: PyLuceneKNN
-    disabled: false
+    disabled: true
     docker_tag: ann-benchmarks-luceneknn
     module: ann_benchmarks.algorithms.luceneknn
     name: luceneknn

--- a/ann_benchmarks/algorithms/pgvector/config.yml
+++ b/ann_benchmarks/algorithms/pgvector/config.yml
@@ -2,7 +2,7 @@ float:
   any:
   - base_args: ['@metric']
     constructor: PGVector
-    disabled: false
+    disabled: true
     docker_tag: ann-benchmarks-pgvector
     module: ann_benchmarks.algorithms.pgvector
     name: pgvector


### PR DESCRIPTION
Disable the algorithms 'luceneknn' and 'pgvector'.
            They throw error during execution. They can be enabled again once they run smoothly. The dataset used was "glove-25-angular".

Please find below the screenshots showing the error during executing:
1. 'luceneknn'
Screenshot 1
![Screenshot 2024-01-14 at 2 27 28 PM](https://github.com/erikbern/ann-benchmarks/assets/44113600/0c124a71-3841-45ad-a1bc-c9af254ca5d2)
Screenshot 2
![Screenshot 2024-01-14 at 2 27 56 PM](https://github.com/erikbern/ann-benchmarks/assets/44113600/13abde1e-b42d-4b33-b783-3338534ed866)
Screenshot 3
![Screenshot 2024-01-14 at 2 29 02 PM](https://github.com/erikbern/ann-benchmarks/assets/44113600/1134b898-e188-40f5-a31f-0fd27bab6f6d)

2. 'pgvector'
Screenshot 1
![Screenshot 2024-01-14 at 4 31 09 PM](https://github.com/erikbern/ann-benchmarks/assets/44113600/916a2837-edd1-4f09-970f-98ddc555704b)
Screenshot 2
![Screenshot 2024-01-14 at 4 31 43 PM](https://github.com/erikbern/ann-benchmarks/assets/44113600/05bccc59-e690-4944-a5f7-e72c0ca1746a)
Screenshot 3
![Screenshot 2024-01-14 at 4 32 10 PM](https://github.com/erikbern/ann-benchmarks/assets/44113600/70f60ad2-8177-47ea-ab46-83bd7b1d4081)
