### PR TITLE
Update pgvector loading method to use binary format

### DIFF
--- a/ann_benchmarks/algorithms/pgvector/module.py
+++ b/ann_benchmarks/algorithms/pgvector/module.py
@@ -30,7 +30,8 @@ class PGVector(BaseANN):
         cur.execute("CREATE TABLE items (id int, embedding vector(%d))" % X.shape[1])
         cur.execute("ALTER TABLE items ALTER COLUMN embedding SET STORAGE PLAIN")
         print("copying data...")
-        with cur.copy("COPY items (id, embedding) FROM STDIN") as copy:
+        with cur.copy("COPY items (id, embedding) FROM STDIN WITH (FORMAT BINARY)") as copy:
+            copy.set_types(["int4", "vector"])
             for i, embedding in enumerate(X):
                 copy.write_row((i, embedding))
         print("creating index...")


### PR DESCRIPTION
Particularly on large vector types, the pgvector module was spending significant time on converting floating point values to ASCII before being transmitted to the PostgreSQL server. This changes keeps the format in binary, reducing overhead. One test demonstrated a 63% reduction in load time, which would have an impact on the overall "build" time as reported by this benchmark.