### PR TITLE
pgvector updates

### DIFF
--- a/ann_benchmarks/algorithms/pgvector/Dockerfile
+++ b/ann_benchmarks/algorithms/pgvector/Dockerfile
@@ -5,8 +5,10 @@ FROM ann-benchmarks
 RUN git clone https://github.com/pgvector/pgvector /tmp/pgvector
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y install tzdata
-RUN apt-get update && apt-get install -y --no-install-recommends build-essential postgresql postgresql-server-dev-all
-RUN sh -c 'echo "local all all trust" > /etc/postgresql/14/main/pg_hba.conf'
+RUN apt-get update && apt-get install -y --no-install-recommends build-essential postgresql-common
+RUN /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y
+RUN apt-get install -y --no-install-recommends postgresql-16 postgresql-server-dev-16
+RUN sh -c 'echo "local all all trust" > /etc/postgresql/16/main/pg_hba.conf'
 RUN cd /tmp/pgvector && \
 	make clean && \
 	make OPTFLAGS="-march=native -mprefer-vector-width=512" && \
@@ -17,8 +19,10 @@ RUN service postgresql start && \
     psql -c "CREATE USER ann WITH ENCRYPTED PASSWORD 'ann'" && \
     psql -c "CREATE DATABASE ann" && \
     psql -c "GRANT ALL PRIVILEGES ON DATABASE ann TO ann" && \
+    psql -d ann -c "GRANT ALL ON SCHEMA public TO ann" && \
     psql -d ann -c "CREATE EXTENSION vector" && \
     psql -c "ALTER USER ann SET maintenance_work_mem = '4GB'" && \
+    psql -c "ALTER USER ann SET max_parallel_maintenance_workers = 0" && \
     psql -c "ALTER SYSTEM SET shared_buffers = '4GB'"
 USER root
 


### PR DESCRIPTION
Hi, this PR makes two updates to pgvector:

1. Fixes `could not resize shared memory segment` error with pgvector 0.6.0 and Docker by explicitly disabling parallel index builds (`max_parallel_maintenance_workers` change)
2. Updates Postgres from 14 to 16 (which requires the `GRANT` change)