### PR TITLE
fix docker tag for Faiss HNSW

### DIFF
--- a/ann_benchmarks/algorithms/faiss_hnsw/config.yml
+++ b/ann_benchmarks/algorithms/faiss_hnsw/config.yml
@@ -3,7 +3,7 @@ float:
   - base_args: ['@metric']
     constructor: FaissHNSW
     disabled: false
-    docker_tag: ann-benchmarks-faiss
+    docker_tag: ann-benchmarks-faiss_hnsw
     module: ann_benchmarks.algorithms.faiss_hnsw
     name: hnsw(faiss)
     run_groups:


### PR DESCRIPTION
Fixed an error that occurred when executing in an environment where the docker image for faiss_hnsw existed and the docker image for faiss did not exist.

This will be failed:

```console
# In the environment where ANN Benchmarks is executed for the first time

$ python install.py --algorithm faiss_hnsw

$ python run.py --algorithm 'hnsw(faiss)
```
