### PR TITLE
Skip loading base/config.yml on Windows.

### DIFF
--- a/ann_benchmarks/definitions.py
+++ b/ann_benchmarks/definitions.py
@@ -127,7 +127,7 @@ def get_config_files(base_dir: str = "ann_benchmarks/algorithms") -> List[str]:
     """Get config files for all algorithms."""
     config_files = glob.glob(os.path.join(base_dir, "*", "config.yml"))
     return list(
-        set(config_files) - {f"{base_dir}/base/config.yml"}
+        set(config_files) - {os.path.join(base_dir, "base", "config.yml")}
     )
 
 def load_configs(point_type: str, base_dir: str = "ann_benchmarks/algorithms") -> Dict[str, Any]:
@@ -138,8 +138,6 @@ def load_configs(point_type: str, base_dir: str = "ann_benchmarks/algorithms") -
         with open(config_file, 'r') as stream:
             try:
                 config_data = yaml.safe_load(stream)
-                if config_data is None:
-                    continue
                 algorithm_name = os.path.basename(os.path.dirname(config_file))
                 if point_type in config_data:
                     configs[algorithm_name] = config_data[point_type]

--- a/ann_benchmarks/definitions.py
+++ b/ann_benchmarks/definitions.py
@@ -138,6 +138,8 @@ def load_configs(point_type: str, base_dir: str = "ann_benchmarks/algorithms") -
         with open(config_file, 'r') as stream:
             try:
                 config_data = yaml.safe_load(stream)
+                if config_data is None:
+                    continue
                 algorithm_name = os.path.basename(os.path.dirname(config_file))
                 if point_type in config_data:
                     configs[algorithm_name] = config_data[point_type]


### PR DESCRIPTION
`load_configs()` failed always because of ann_benchmarks/algorithms/base/config.yaml is empty.
`yaml.safe_load()` returns `None` for empty steam (https://pyyaml.org/wiki/PyYAMLDocumentation).

This fixes it with skipping `None` which returned from `yaml.safe_load()`