### PR TITLE
Fix logic in _get_algorithm_definitions to avoid skipping algorithm definitions

### DIFF
--- a/ann_benchmarks/definitions.py
+++ b/ann_benchmarks/definitions.py
@@ -166,8 +166,7 @@ def _get_algorithm_definitions(point_type: str, distance_metric: str) -> Dict[st
     metric. For example, `ann_benchmarks.algorithms.nmslib` has two definitions for euclidean float
     data: specifically `SW-graph(nmslib)` and `hnsw(nmslib)`, even though the module is named nmslib.
 
-    If an algorithm has an 'any' distance metric is found for the specific point type, it is used 
-    regardless (and takes precendence) over if the distance metric is present.
+    If an algorithm has an 'any' distance metric, it is also included.
 
     Returns: A mapping from the algorithm name (not the algorithm class), to the algorithm definitions, i.e.:
     ```
@@ -195,11 +194,10 @@ def _get_algorithm_definitions(point_type: str, distance_metric: str) -> Dict[st
     # param `_` is filename, not specific name
     for _, config in configs.items():
         c = []
-        if "any" in config: # "any" branch must come first
-            c = config["any"]
-        elif distance_metric in config:
-            c = config[distance_metric]
-
+        if "any" in config:
+            c.extend(config["any"])
+        if distance_metric in config:
+            c.extend(config[distance_metric])
         for cc in c:
             definitions[cc.pop("name")] = cc
 


### PR DESCRIPTION
Maybe I'm missing something, but it seems like the logic in `_get_algorithm_definitions` leads to incorrectly skipping algorithm definitions, which I've attempted to fix here.

For example, elastiknn has definitions for the "point types" `any` and `euclidean`: https://github.com/erikbern/ann-benchmarks/blob/main/ann_benchmarks/algorithms/elastiknn/config.yml

But, if I run `python run.py --algorithm elastiknn-l2lsh --dataset random-xs-20-euclidean --run-disabled --timeout 30 --local --force --runs 1`, I get the "Nothing to run" exception. That doesn't make sense IMO. Elastiknn has definitions for the `euclidean` point type, so there is not "nothing to run".

It seems that the non-any point type is skipped because of the logic in `_get_algorithm_definitions`. If an algorithm has definitions for `any`, they take precedence over the definitions for a specific point type (euclidean). We can fix this by changing the logic so that it accumulates all matching point types, rather than just taking the `any` type and skipping the rest. In other words, we change the `elif` to a second `if`.