### PR TITLE
fix error reporting of runner

### DIFF
--- a/ann_benchmarks/runner.py
+++ b/ann_benchmarks/runner.py
@@ -381,7 +381,8 @@ def _handle_container_return_value(
         msg = msg.format(exit_code)
 
     if exit_code not in [0, None]:
-        logger.error(colors.color(container.logs().decode(), fg="red"))
+        for line in container.logs(stream=True):
+            logger.error(colors.color(line.decode(), fg="red"))
         logger.error(msg)
     else:
         logger.info(msg)


### PR DESCRIPTION
When an error is reported, container.logs() returns an iterator over lines of bytes. The decode() function should apply to each line, not to the iterator, otherwise we get no logs, but an error message saying there is no decode() function in the iterator.

This change follows the same pattern as stream_logs() in the same file.