### PR TITLE
Fix recall for Hamming distance

### DIFF
--- a/ann_benchmarks/distance.py
+++ b/ann_benchmarks/distance.py
@@ -27,7 +27,7 @@ class Metric(NamedTuple):
 
 metrics = {
     "hamming": Metric(
-        distance=lambda a, b: np.sum(a.astype(np.bool_) ^ b.astype(np.bool_)),
+        distance=lambda a, b: np.mean(a.astype(np.bool_) ^ b.astype(np.bool_)),
         distance_valid=lambda a: True
     ),
     "jaccard": Metric(


### PR DESCRIPTION
Both `sift-256-hamming` and `word2bits-800-hamming` always report 0 recall, as the distances in the HDF5 files are floats between 0 and 1 rather than the Hamming distance. Multiplying by the dataset dimensions fixes it.

This issue is likely the cause of #420.