### PR TITLE
Enable to build pgvector simultaneously for ARM and Intel

### DIFF
--- a/ann_benchmarks/algorithms/pgvector/Dockerfile
+++ b/ann_benchmarks/algorithms/pgvector/Dockerfile
@@ -9,10 +9,20 @@ RUN apt-get update && apt-get install -y --no-install-recommends build-essential
 RUN /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y
 RUN apt-get install -y --no-install-recommends postgresql-16 postgresql-server-dev-16
 RUN sh -c 'echo "local all all trust" > /etc/postgresql/16/main/pg_hba.conf'
-RUN cd /tmp/pgvector && \
-	make clean && \
-	make OPTFLAGS="-march=native -mprefer-vector-width=512" && \
-	make install
+
+# Dynamically set OPTFLAGS based on the architecture
+RUN ARCH=$(uname -m) && \
+    if [ "$ARCH" = "aarch64" ]; then \
+        OPTFLAGS="-march=native -msve-vector-bits=512"; \
+    elif [ "$ARCH" = "x86_64" ]; then \
+        OPTFLAGS="-march=native -mprefer-vector-width=512"; \
+    else \
+        OPTFLAGS="-march=native"; \
+    fi && \
+    cd /tmp/pgvector && \
+    make clean && \
+    make OPTFLAGS="$OPTFLAGS" && \
+    make install
 
 USER postgres
 RUN service postgresql start && \


### PR DESCRIPTION
An attempt to build `pgvector` container on ARM based MacOS failed with the following error:

```
 => ERROR [ 8/10] RUN cd /tmp/pgvector &&  make clean &&  make OPTFLAGS="-march=native -mprefer-vector-width=512" &&  make install                                0.3s
------
 > [ 8/10] RUN cd /tmp/pgvector &&      make clean &&   make OPTFLAGS="-march=native -mprefer-vector-width=512" &&      make install:
0.246 rm -f vector.so   libvector.a  libvector.pc
0.246 rm -f src/bitvector.o src/halfvec.o src/hnsw.o src/hnswbuild.o src/hnswinsert.o src/hnswscan.o src/hnswutils.o src/hnswvacuum.o src/ivfbuild.o src/ivfflat.o src/
ivfinsert.o src/ivfkmeans.o src/ivfscan.o src/ivfutils.o src/ivfvacuum.o src/sparsevec.o src/vector.o src/bitvector.bc src/halfvec.bc src/hnsw.bc src/hnswbuild.bc src/
hnswinsert.bc src/hnswscan.bc src/hnswutils.bc src/hnswvacuum.bc src/ivfbuild.bc src/ivfflat.bc src/ivfinsert.bc src/ivfkmeans.bc src/ivfscan.bc src/ivfutils.bc src/iv
fvacuum.bc src/sparsevec.bc src/vector.bc
0.247 rm -rf sql/vector--0.6.2.sql
0.247 rm -rf results/ regression.diffs regression.out tmp_check/ tmp_check_iso/ log/ output_iso/
0.257 gcc -Wall -Wmissing-prototypes -Wpointer-arith -Wdeclaration-after-statement -Werror=vla -Wendif-labels -Wmissing-format-attribute -Wimplicit-fallthrough=3 -Wcas
t-function-type -Wshadow=compatible-local -Wformat-security -fno-strict-aliasing -fwrapv -fexcess-precision=standard -Wno-format-truncation -Wno-stringop-truncation -m
outline-atomics -g -g -O2 -flto=auto -ffat-lto-objects -flto=auto -ffat-lto-objects -fstack-protector-strong -Wformat -Werror=format-security -march=native -mprefer-ve
ctor-width=512 -ftree-vectorize -fassociative-math -fno-signed-zeros -fno-trapping-math -fPIC -fvisibility=hidden -I. -I./ -I/usr/include/postgresql/16/server -I/usr/i
nclude/postgresql/internal  -Wdate-time -D_FORTIFY_SOURCE=2 -D_GNU_SOURCE -I/usr/include/libxml2   -c -o src/bitvector.o src/bitvector.c
0.263 gcc: error: unrecognized command-line option '-mprefer-vector-width=512'; did you mean '-msve-vector-bits=512'?
0.263 make: *** [<builtin>: src/bitvector.o] Error 1
------
Dockerfile:12
--------------------
  11 |     RUN sh -c 'echo "local all all trust" > /etc/postgresql/16/main/pg_hba.conf'
  12 | >>> RUN cd /tmp/pgvector && \
  13 | >>>      make clean && \
  14 | >>>      make OPTFLAGS="-march=native -mprefer-vector-width=512" && \
  15 | >>>      make install
  16 |
--------------------
ERROR: failed to solve: process "/bin/sh -c cd /tmp/pgvector && \tmake clean && \tmake OPTFLAGS=\"-march=native -mprefer-vector-width=512\" && \tmake install" did not
complete successfully: exit code: 2
```

This PR makes it possible to build `pgvector` on both architectures. 