### PR TITLE
Optimize the peak memory usage when loading dataset.

### DIFF
--- a/ann_benchmarks/distance.py
+++ b/ann_benchmarks/distance.py
@@ -115,7 +115,7 @@ def dataset_transform(dataset: h5py.Dataset) -> Tuple[Union[np.ndarray, List[np.
         Tuple[Union[np.ndarray, List[np.ndarray]], Union[np.ndarray, List[np.ndarray]]]: Tuple of training and testing data in conventional format.
     """
     if dataset.attrs.get("type", "dense") != "sparse":
-        return np.array(dataset["train"]), np.array(dataset["test"])
+        return np.asarray(dataset["train"]), np.asarray(dataset["test"])
 
     # we store the dataset as a list of integers, accompanied by a list of lengths in hdf5
     # so we transform it back to the format expected by the algorithms here (array of array of ints)

--- a/ann_benchmarks/runner.py
+++ b/ann_benchmarks/runner.py
@@ -152,8 +152,8 @@ def load_and_transform_dataset(dataset_name: str) -> Tuple[
         Tuple: Transformed datasets.
     """
     D, dimension = get_dataset(dataset_name)
-    X_train = numpy.array(D["train"])
-    X_test = numpy.array(D["test"])
+    X_train = numpy.asarray(D["train"])
+    X_test = numpy.asarray(D["test"])
     distance = D.attrs["distance"]
 
     print(f"Got a train set of size ({X_train.shape[0]} * {dimension})")


### PR DESCRIPTION
I've made a small optimization in data loading process that reduces peak memory usage when handling large datasets. 
Previously, we were using np.array() to convert large datasets from h5py objects into NumPy arrays. This operation, while straightforward, was causing a spike in memory usage due to the creation of a new array copy, which could lead to OOM errors when working with particularly large datasets. 
To mitigate this issue, I have replaced np.array() with np.asarray() in the relevant sections of the code. The np.asarray() function, unlike np.array(), will attempt to pass through the input data without creating a new array copy if the input is already a NumPy array. This behavior helps to reduce unnecessary memory allocation and can be particularly effective in scenarios where memory is a constraint.