### PR TITLE
Fix Hamming distance test to reflect normalized values

### DIFF
--- a/test/distance_test.py
+++ b/test/distance_test.py
@@ -18,11 +18,11 @@ def test_hamming():
 
     p = numpy.array([1, 1, 0, 0], dtype=numpy.bool_)
     q = numpy.array([1, 0, 0, 1], dtype=numpy.bool_)
-    assert dist(p, q) == pytest.approx(2)
+    assert dist(p, q) == pytest.approx(0.5)
 
     p = numpy.array([1, 1, 0, 0])
     q = numpy.array([1, 0, 0, 1])
-    assert dist(p, q) == pytest.approx(2)
+    assert dist(p, q) == pytest.approx(0.5)
 
 
 def test_angular():


### PR DESCRIPTION
# Description:
This PR updates the test_hamming function in our pytest suite to correctly reflect the normalized Hamming distance. The previous test was expecting a raw Hamming distance of 2, but since our metric function calculates the normalized Hamming distance, the expected value should be 0.5.

```python
    # ann-benchmarks/ann_benchmarks/distance.py: line 29
    "hamming": Metric(
        distance=lambda a, b: np.mean(a.astype(np.bool_) ^ b.astype(np.bool_)),
        distance_valid=lambda a: True
    ),
```

# Changes:

Updated the expected values in test_hamming from 2 to 0.5 to align with the normalized Hamming distance calculation.
Reasoning:
The metrics["hamming"].distance function calculates the normalized Hamming distance by taking the mean of the boolean XOR results. Thus, for arrays p and q given in the tests:

p = [1, 1, 0, 0]
q = [1, 0, 0, 1]
The raw Hamming distance is 2 (two differing positions), and the normalized Hamming distance is 2/4 = 0.5.