### PR TITLE
Use custom definitions for algorithms

### DIFF
--- a/ann_benchmarks/definitions.py
+++ b/ann_benchmarks/definitions.py
@@ -341,11 +341,11 @@ def create_definitions_from_algorithm(name: str, algo: Dict[str, Any], dimension
     return definitions
 
 def get_definitions(
-        dimension: int,
-        point_type: str = "float",
-        distance_metric: str = "euclidean",
-        count: int = 10,
-        base_dir: str = "ann_benchmarks/algorithms"
+    dimension: int,
+    point_type: str = "float",
+    distance_metric: str = "euclidean",
+    count: int = 10,
+    base_dir: str = "ann_benchmarks/algorithms"
 ) -> List[Definition]:
     algorithm_definitions = _get_algorithm_definitions(point_type=point_type,
                                                        distance_metric=distance_metric,

--- a/ann_benchmarks/definitions.py
+++ b/ann_benchmarks/definitions.py
@@ -159,7 +159,7 @@ def _get_definitions(base_dir: str = "ann_benchmarks/algorithms") -> Dict[str, D
                 print(f"Error loading YAML from {config_file}: {e}")
     return configs
 
-def _get_algorithm_definitions(point_type: str, distance_metric: str) -> Dict[str, Dict[str, Any]]:
+def _get_algorithm_definitions(point_type: str, distance_metric: str, base_dir: str = "ann_benchmarks/algorithms") -> Dict[str, Dict[str, Any]]:
     """Get algorithm definitions for a specific point type and distance metric.
     
     A specific algorithm folder can have multiple algorithm definitions for a given point type and 
@@ -188,7 +188,7 @@ def _get_algorithm_definitions(point_type: str, distance_metric: str) -> Dict[st
     }
     ```
     """
-    configs = load_configs(point_type)
+    configs = load_configs(point_type, base_dir)
     definitions = {}
 
     # param `_` is filename, not specific name
@@ -341,12 +341,16 @@ def create_definitions_from_algorithm(name: str, algo: Dict[str, Any], dimension
     return definitions
 
 def get_definitions(
-    dimension: int, 
-    point_type: str = "float", 
-    distance_metric: str = "euclidean", 
-    count: int = 10
+        dimension: int,
+        point_type: str = "float",
+        distance_metric: str = "euclidean",
+        count: int = 10,
+        base_dir: str = "ann_benchmarks/algorithms"
 ) -> List[Definition]:
-    algorithm_definitions = _get_algorithm_definitions(point_type=point_type,  distance_metric=distance_metric)
+    algorithm_definitions = _get_algorithm_definitions(point_type=point_type,
+                                                       distance_metric=distance_metric,
+                                                       base_dir=base_dir
+                                                       )
 
     definitions: List[Definition] = []
 

--- a/ann_benchmarks/main.py
+++ b/ann_benchmarks/main.py
@@ -312,7 +312,8 @@ def main():
         dimension=dimension,
         point_type=dataset.attrs.get("point_type", "float"),
         distance_metric=dataset.attrs["distance"],
-        count=args.count
+        count=args.count,
+        base_dir=args.definitions,
     )
     random.shuffle(definitions)
 


### PR DESCRIPTION
Hi! Great benchmark that you have here.

I noticed that the value of the `--definitions` argument is only used when listing all available algorithms. Correct me if I'm wrong, but I wanted to pass my own algorithm configurations, which are stored elsewhere, by using `--definitions`. This doesn't work because the program uses the default path `ann-benchmarks/algorithms`.
