### PR TITLE
Update Elastiknn to latest release and latest benchmark parameters

### DIFF
--- a/ann_benchmarks/algorithms/elastiknn/Dockerfile
+++ b/ann_benchmarks/algorithms/elastiknn/Dockerfile
@@ -13,13 +13,13 @@ WORKDIR /home/elasticsearch
 USER elasticsearch
 
 # Install elasticsearch.
-RUN curl -o elasticsearch.tar.gz https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-8.12.2-linux-x86_64.tar.gz
+RUN curl -o elasticsearch.tar.gz https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-8.15.0-linux-x86_64.tar.gz
 RUN tar xzf elasticsearch.tar.gz
 RUN mv elasticsearch-* elasticsearch && rm elasticsearch.tar.gz
 
 # Install plugin.
 RUN /home/elasticsearch/elasticsearch/bin/elasticsearch-plugin install --batch \
-    https://github.com/alexklibisz/elastiknn/releases/download/8.12.2.1/elastiknn-8.12.2.1.zip
+    https://github.com/alexklibisz/elastiknn/releases/download/8.15.0.1/elastiknn-8.15.0.1.zip
 
 # Configuration
 # Backup the original configurations, which can be useful for comparing.
@@ -66,10 +66,7 @@ USER root
 WORKDIR /home/app
 
 # Install python client.
-# Using no-deps because scipy (1.7.0) is incompatible with the container version of Python (3.6).
-# Then we need to install the deps manually.
-RUN python3 -m pip install --no-deps elastiknn-client==8.6.2.0
-RUN python3 -m pip install elasticsearch==8.6.2 dataclasses-json==0.3.7 tqdm==4.61.1
+RUN python3 -m pip install elastiknn-client==8.15.0.1
 
 # Custom entrypoint that also starts the Elasticsearch server in the background
 RUN echo '\

--- a/ann_benchmarks/algorithms/elastiknn/config.yml
+++ b/ann_benchmarks/algorithms/elastiknn/config.yml
@@ -18,5 +18,5 @@ float:
     name: elastiknn-l2lsh
     run_groups:
       elastiknn-l2lsh:
-        args: [[100], [4], [1024, 2048]]
-        query_args: [[500, 1000], [0, 3]]
+        args: [[175], [7], [3900]]
+        query_args: [[100,500,1000], [0]]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 ansicolors==1.1.8
-docker==6.1.3
+docker==7.1.0
 h5py==3.8.0
 matplotlib==3.6.3
 numpy==1.24.2


### PR DESCRIPTION
This also includes the change from #543, which was necessary to get this to run.