### PR TITLE
Add multimodal dataset based on COCO text-image pairs

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ We have a number of precomputed data sets in HDF5 format. All data sets have bee
 | [NYTimes](https://archive.ics.uci.edu/ml/datasets/bag+of+words)   |        256 |    290,000 |    10,000 |       100 | Angular   | [HDF5](http://ann-benchmarks.com/nytimes-256-angular.hdf5) (301MB)         |
 | [SIFT](http://corpus-texmex.irisa.fr/)                           |        128 |  1,000,000 |    10,000 |       100 | Euclidean | [HDF5](http://ann-benchmarks.com/sift-128-euclidean.hdf5) (501MB)          |
 | [Last.fm](https://github.com/erikbern/ann-benchmarks/pull/91)     |         65 |    292,385 |    50,000 |       100 | Angular   | [HDF5](http://ann-benchmarks.com/lastfm-64-dot.hdf5) (135MB)               |
+| [COCO-I2I](https://cocodataset.org/)                              |        512 |    118,287 |     5,000 |       100 | Angular   | [HDF5](https://github.com/fabiocarrara/str-encoders/releases/download/v0.1.3/coco-i2i-512-angular.hdf5) (125MB) |
+| [COCO-T2I](https://cocodataset.org/)                              |        512 |    118,287 |     5,000 |       100 | Angular   | [HDF5](https://github.com/fabiocarrara/str-encoders/releases/download/v0.1.3/coco-t2i-512-angular.hdf5) (125MB) |
 
 Results
 =======

--- a/ann_benchmarks/datasets.py
+++ b/ann_benchmarks/datasets.py
@@ -569,6 +569,11 @@ def dbpedia_entities_openai_1M(out_fn, n = None):
 
     write_output(X_train, X_test, out_fn, "angular")
 
+def coco(out_fn: str, kind: str):
+    assert kind in ('t2i', 'i2i')
+    url = "https://github.com/fabiocarrara/str-encoders/releases/download/v0.1.3/coco-%s-512-angular.hdf5" % kind
+    download(url, out_fn)
+
 
 DATASETS: Dict[str, Callable[[str], None]] = {
     "deep-image-96-angular": deep_image,
@@ -598,6 +603,8 @@ DATASETS: Dict[str, Callable[[str], None]] = {
     "movielens1m-jaccard": movielens1m,
     "movielens10m-jaccard": movielens10m,
     "movielens20m-jaccard": movielens20m,
+    "coco-i2i-512-angular": lambda out_fn: coco(out_fn, "i2i"),
+    "coco-t2i-512-angular": lambda out_fn: coco(out_fn, "t2i"),
 }
 
 DATASETS.update({


### PR DESCRIPTION
This PR adds two ANN datasets drived from the [COCO](https://cocodataset.org/) text-image pairs dataset:

1. **COCO Text-to-Image Multimodal Dataset (`coco-t2i-512-angular`)**:
   - Text is used as queries, and images comprise the search set.
   - This dataset presents a challenge due to the distribution data shift between queries and the search set, with the 100 nearest neighbors of queries having a cosine similarity of 0.30 +- 0.02.
2. **COCO Image-to-Image Intra-modal Dataset (`coco-i2i-512-angular`)**:
   - Images are used as both queries and search set.
   - This dataset does not exhibit the distribution shift and can serve as a reference, sharing the same datapoints as the `t2i` dataset.

**Extraction Process**
Features vectors are the CLS output token of the [OpenAI's CLIP](https://github.com/openai/CLIP) with ViT-B/16 architecture (512 dimensions) of the visual or textual encoder. Thanks to @mesnico for performing the extraction.

**Split definition**
Based on Karpathy's split of COCO 2014:

 - The search sets include 118,287 vectors extracted from training set images.
 - Queries:
   - Visual (`i2i`): 5,000 vectors from validation set images.
   - Textual (`t2i`): 5,000 vectors from the first caption (out of the five available) of validation set images.

@maumueller: Lucia (@vadicamo) told me you were searching for a multimodal dataset for the SISAP indexing challenge. If it's still needed, check whether those could be a good fit. Let me know if you'd like more details.