### PR TITLE
Modify the string of hnswlib's parameters to add efQuery

### DIFF
--- a/ann_benchmarks/algorithms/hnswlib/module.py
+++ b/ann_benchmarks/algorithms/hnswlib/module.py
@@ -9,8 +9,6 @@ class HnswLib(BaseANN):
         self.metric = {"angular": "cosine", "euclidean": "l2"}[metric]
         self.method_param = method_param
         # print(self.method_param,save_index,query_param)
-        # self.ef=query_param['ef']
-        # self.name = "hnswlib (%s)" % (self.method_param)
 
     def fit(self, X):
         # Only l2 is supported currently

--- a/ann_benchmarks/algorithms/hnswlib/module.py
+++ b/ann_benchmarks/algorithms/hnswlib/module.py
@@ -10,7 +10,7 @@ class HnswLib(BaseANN):
         self.method_param = method_param
         # print(self.method_param,save_index,query_param)
         # self.ef=query_param['ef']
-        self.name = "hnswlib (%s)" % (self.method_param)
+        # self.name = "hnswlib (%s)" % (self.method_param)
 
     def fit(self, X):
         # Only l2 is supported currently
@@ -24,6 +24,7 @@ class HnswLib(BaseANN):
 
     def set_query_arguments(self, ef):
         self.p.set_ef(ef)
+        self.name = "hnswlib (%s, 'efQuery': %s)" % (self.method_param, ef)
 
     def query(self, v, n):
         # print(np.expand_dims(v,axis=0).shape)


### PR DESCRIPTION
When exporting the CSV results of hnswlib, the parameters in the file do not include the ef value from the query arguments. This pull request modifies self.name to include it, facilitating performance comparison.