### PR TITLE
Disable non open source

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -33,7 +33,6 @@ jobs:
           - balltree
           - bruteforce
           - ckdtree
-          - descartes
           - diskann
           - dolphinnpy
           - elasticsearch
@@ -44,7 +43,6 @@ jobs:
           - glass
           - hnswlib
           - kdtree
-          - kgn
           - luceneknn
           - milvus
           - mrpt
@@ -62,7 +60,6 @@ jobs:
           - redisearch
           - qdrant
           - qg_ngt
-          - qsg_ngt
           - scann
           - sptag
           - tinyknn

--- a/ann_benchmarks/algorithms/descartes/config.yml
+++ b/ann_benchmarks/algorithms/descartes/config.yml
@@ -2,7 +2,7 @@ float:
   any:
   - base_args: ['@metric']
     constructor: fng
-    disabled: false
+    disabled: true
     docker_tag: ann-benchmarks-descartes
     module: ann_benchmarks.algorithms.descartes
     name: descartes(01AI)

--- a/ann_benchmarks/algorithms/kgn/config.yml
+++ b/ann_benchmarks/algorithms/kgn/config.yml
@@ -2,7 +2,7 @@ float:
   euclidean:
     - base_args: ['@metric','@dimension']
       constructor: Kgn
-      disabled: false
+      disabled: true
       docker_tag: ann-benchmarks-kgn
       module: ann_benchmarks.algorithms.kgn
       name: kgn
@@ -21,7 +21,7 @@ float:
   angular:
     - base_args: ['@metric','@dimension']
       constructor: Kgn
-      disabled: false
+      disabled: true
       docker_tag: ann-benchmarks-kgn
       module: ann_benchmarks.algorithms.kgn
       name: kgn

--- a/ann_benchmarks/algorithms/qsg_ngt/config.yml
+++ b/ann_benchmarks/algorithms/qsg_ngt/config.yml
@@ -2,7 +2,7 @@ float:
   any:
   - base_args: ['@metric', Float, 0.1]
     constructor: QSG
-    disabled: false
+    disabled: true
     docker_tag: ann-benchmarks-qsg_ngt
     module: ann_benchmarks.algorithms.qsg_ngt
     name: qsgngt


### PR DESCRIPTION
I don't think we should feature ones that aren't open source. We can still keep them in the code base though.