### PR TITLE
Upgrade pybind11 for NGT

### DIFF
--- a/ann_benchmarks/algorithms/onng_ngt/Dockerfile
+++ b/ann_benchmarks/algorithms/onng_ngt/Dockerfile
@@ -2,7 +2,7 @@ FROM ann-benchmarks
 
 RUN apt update
 RUN apt install -y git cmake g++ python3 python3-setuptools python3-pip libblas-dev liblapack-dev
-RUN pip3 install wheel pybind11==2.5.0
+RUN pip3 install wheel pybind11==2.13.6
 RUN git clone -b main https://github.com/yahoojapan/ngt.git
 RUN mkdir -p ngt/build
 RUN cd ngt/build && cmake -DNGTQG_NO_ROTATION=ON -DNGTQG_ZERO_GLOBAL=ON ..

--- a/ann_benchmarks/algorithms/onng_ngt/config.yml
+++ b/ann_benchmarks/algorithms/onng_ngt/config.yml
@@ -2,7 +2,7 @@ float:
   any:
   - base_args: ['@metric', Float, 0.1]
     constructor: ONNG
-    disabled: true
+    disabled: false
     docker_tag: ann-benchmarks-onng_ngt
     module: ann_benchmarks.algorithms.onng_ngt
     name: NGT-onng

--- a/ann_benchmarks/algorithms/panng_ngt/Dockerfile
+++ b/ann_benchmarks/algorithms/panng_ngt/Dockerfile
@@ -2,7 +2,7 @@ FROM ann-benchmarks
 
 RUN apt update
 RUN apt install -y git cmake g++ python3 python3-setuptools python3-pip libblas-dev liblapack-dev
-RUN pip3 install wheel pybind11==2.5.0
+RUN pip3 install wheel pybind11==2.13.6
 RUN git clone -b main https://github.com/yahoojapan/ngt.git
 RUN mkdir -p ngt/build
 RUN cd ngt/build && cmake -DNGTQG_NO_ROTATION=ON -DNGTQG_ZERO_GLOBAL=ON ..

--- a/ann_benchmarks/algorithms/panng_ngt/config.yml
+++ b/ann_benchmarks/algorithms/panng_ngt/config.yml
@@ -2,7 +2,7 @@ float:
   any:
   - base_args: ['@metric', Float]
     constructor: PANNG
-    disabled: false
+    disabled: true
     docker_tag: ann-benchmarks-panng_ngt
     module: ann_benchmarks.algorithms.panng_ngt
     name: NGT-panng

--- a/ann_benchmarks/algorithms/qg_ngt/Dockerfile
+++ b/ann_benchmarks/algorithms/qg_ngt/Dockerfile
@@ -2,7 +2,7 @@ FROM ann-benchmarks
 
 RUN apt update
 RUN apt install -y git cmake g++ python3 python3-setuptools python3-pip libblas-dev liblapack-dev
-RUN pip3 install wheel pybind11==2.5.0
+RUN pip3 install wheel pybind11==2.13.6
 RUN git clone -b main https://github.com/yahoojapan/ngt.git
 RUN mkdir -p ngt/build
 RUN cd ngt/build && cmake -DNGTQG_NO_ROTATION=ON -DNGTQG_ZERO_GLOBAL=ON ..


### PR DESCRIPTION
I upgraded the pybind11 version used in NGT. The previous version was outdated, causing an issue where all elements in the search result array had the same value. Additionally, for some reason, ONNG had been disabled, so I took this opportunity to re-enable it as the primary method and disable PANNG instead.