### PR TITLE
optimize: use elasticsearch msearch API for batch queries

### DIFF
--- a/ann_benchmarks/algorithms/elasticsearch/Dockerfile
+++ b/ann_benchmarks/algorithms/elasticsearch/Dockerfile
@@ -45,7 +45,7 @@ path.logs: /usr/share/elasticsearch/logs\n\
 bootstrap.memory_lock: true\n\
 thread_pool.write.size: 1\n\
 thread_pool.search.size: 1\n\
-thread_pool.search.queue_size: 1\n\
+thread_pool.search.queue_size: 1000\n\
 xpack.security.enabled: false\n\
 ' > config/elasticsearch.yml
 


### PR DESCRIPTION
This commit refactors the Elasticsearch `batch_query` 
to utilize the msearch (multi-search) API instead of 
sending individual queries in a loop. 

The msearch API allows sending multiple search requests in a single 
HTTP call, which significantly reduces network overhead and improves 
query throughput, especially when performing batch operations.

Changes include:
- Increased Elasticsearch thread_pool.search.queue_size in `Dockerfile`
- Replaced `batch_query` calls with msearch API in `module.py`

Attention：
- Set `thread_pool.search.queue_size=1000` (with thread_pool.search.size=1), 
allowing more requests to queue but still executing them in a single thread