### PR TITLE
Add Navigating Spreading-Out Graph (NSG)

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -51,6 +51,7 @@ jobs:
           - nndescent
           - n2
           - nmslib
+          - nsg
           - onng_ngt
           - opensearchknn
           - panng_ngt

--- a/ann_benchmarks/algorithms/nsg/Dockerfile
+++ b/ann_benchmarks/algorithms/nsg/Dockerfile
@@ -1,0 +1,14 @@
+FROM ann-benchmarks
+
+RUN pip install pybind11 numpy setuptools
+RUN apt-get update -y
+RUN apt-get install -y g++ cmake libboost-dev libgoogle-perftools-dev
+# RUN git clone https://github.com/twuebker/nsg.git
+
+# RUN git fetch origin fix-distance
+# RUN git checkout fix-distance
+# RUN pip install .[knn]
+RUN pip install pynsg[knn]
+
+RUN python -c 'import pynsg'
+

--- a/ann_benchmarks/algorithms/nsg/config.yml
+++ b/ann_benchmarks/algorithms/nsg/config.yml
@@ -12,19 +12,6 @@ float:
           args: {}
           query_args: [[40, 100, 200, 400, 600, 800, 1000]]
         2:
-          arg_groups: [{knn: 200, L: 20, R: 30, C: 300}]
+          arg_groups: [{knn: 400, L: 60, R: 70, C: 500}]
           args: {}
-          query_args: [[40, 100, 200, 400, 600]]
-        3:
-          arg_groups: [{knn: 200, L: 60, R: 70, C: 700}]
-          args: {}
-          query_args: [[100, 200, 400, 600, 800]]
-        4:
-          arg_groups: [{knn: 200, L: 80, R: 100, C: 800}]
-          args: {}
-          query_args: [[200, 400, 600, 800, 1000]]
-        5:
-          arg_groups: [{knn: 400, L: 80, R: 100, C: 800}]
-          args: {}
-          query_args: [[200, 400, 600, 800, 1000]]
- 
+          query_args: [[40, 100, 200, 400, 600, 800, 1000]]

--- a/ann_benchmarks/algorithms/nsg/config.yml
+++ b/ann_benchmarks/algorithms/nsg/config.yml
@@ -1,0 +1,30 @@
+float:
+  any:
+    - base_args: ['@metric']
+      constructor: NSGLib
+      disabled: false
+      docker_tag: ann-benchmarks-nsg
+      module: ann_benchmarks.algorithms.nsg
+      name: nsg
+      run_groups:
+        1:
+          arg_groups: [{knn: 200, L: 40, R: 50, C: 500}]
+          args: {}
+          query_args: [[40, 100, 200, 400, 600, 800, 1000]]
+        2:
+          arg_groups: [{knn: 200, L: 20, R: 30, C: 300}]
+          args: {}
+          query_args: [[40, 100, 200, 400, 600]]
+        3:
+          arg_groups: [{knn: 200, L: 60, R: 70, C: 700}]
+          args: {}
+          query_args: [[100, 200, 400, 600, 800]]
+        4:
+          arg_groups: [{knn: 200, L: 80, R: 100, C: 800}]
+          args: {}
+          query_args: [[200, 400, 600, 800, 1000]]
+        5:
+          arg_groups: [{knn: 400, L: 80, R: 100, C: 800}]
+          args: {}
+          query_args: [[200, 400, 600, 800, 1000]]
+ 

--- a/ann_benchmarks/algorithms/nsg/module.py
+++ b/ann_benchmarks/algorithms/nsg/module.py
@@ -1,0 +1,42 @@
+import numpy as np
+from pynsg import NSG, Metric, create_graph_file
+import faiss
+import os
+import tempfile
+
+from ..base.module import BaseANN
+
+
+class NSGLib(BaseANN):
+    def __init__(self, metric, method_param):
+        self.metric = {"angular": Metric.L2, "euclidean": Metric.L2}[metric]
+        self.L = method_param['L']
+        self.R = method_param['R']
+        self.C = method_param['C']
+        self.knn = method_param['knn']
+        self.normalize = metric == "angular"
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.knn_file = os.path.join(self.tempdir.name, f"knn{self.knn}.graph")
+
+
+    def fit(self, X: np.array):
+        if self.normalize:
+            faiss.normalize_L2(X)
+        # will just build knn graph with metric L2 always since the vectors will be normalized for angular metrics
+        create_graph_file(filename=self.knn_file, x=X, k=200)
+        print(f"created graph file at {self.knn_file}")
+        assert os.path.isfile(self.knn_file), f"KNN file missing: {self.knn_file}"
+        self.index = NSG(dimension=len(X[0]), num_points=len(X), metric=self.metric)
+        self.index.build_index(data=X, knng_path=self.knn_file, L=self.L, R=self.R, C=self.C)
+        self.index.optimize_graph(data=X)
+
+    def set_query_arguments(self, search_L):
+        self.search_L = search_L
+        self.name = f"nsg (L={self.L}, R={self.R}, C={self.C}, knn={self.knn}, search_L={search_L})" 
+
+    def query(self, q: np.array, n: int) -> np.array:
+        return self.index.search_opt(queries=np.expand_dims(q, axis=0), k=n, search_L=self.search_L)[0]
+
+    def done(self):
+        self.tempdir.cleanup()
+


### PR DESCRIPTION
NSG [1] is one of the state-of-the-art algorithms according to recent surveys [2] but still missing in the benchmark. 

Add NSG along with a very rudimentary configuration (based on what the authors said they used for gist and sift datasets) because NSG takes a bit longer to build compared to other indices. The NSG module uses Python bindings called pynsg that are a wrapper around the reference implementation [3].
Fix issue #112 

[1] https://arxiv.org/pdf/1707.00143
[2] https://dl.acm.org/doi/abs/10.1145/3709693
[3] https://github.com/ZJULearning/nsg